### PR TITLE
[Feat/28] 채팅 메시지 전송 및 메시지 받기 기능 구현

### DIFF
--- a/public/scripts/api.js
+++ b/public/scripts/api.js
@@ -116,3 +116,22 @@ async function enterChatroomApi(chatroomUuid) {
     console.error("Error:", error);
   }
 }
+
+async function readChatApi(chatroomUuid, timestamp) {
+  try {
+    const jwtToken = localStorage.getItem("jwtToken");
+    const response = await fetch(`${API_SERVER_URL}/v1/chat/${chatroomUuid}/read?timestamp=${timestamp}`, {
+      headers: {
+        Authorization: `Bearer ${jwtToken}`, // Include JWT token in header
+      },
+    });
+    const data = await response.json();
+    if (data.isSuccess && data.result) {
+      return data.result;
+    } else {
+      throw new Error("readChatApi failed");
+    }
+  } catch (error) {
+    console.error("Error:", error);
+  }
+}

--- a/public/scripts/eventListeners.js
+++ b/public/scripts/eventListeners.js
@@ -252,3 +252,14 @@ function enterChatroom(chatroomUuid) {
     }
   });
 }
+
+// 채팅 전송 폼 제출 시
+form.addEventListener("submit", (e) => {
+  e.preventDefault();
+  if (input.value) {
+    const msg = input.value;
+    // (#10-1) "chat-message" event emit
+    socket.emit("chat-message", { uuid: currentViewingChatroomUuid, message: msg });
+    input.value = "";
+  }
+});

--- a/public/scripts/socket.js
+++ b/public/scripts/socket.js
@@ -2,6 +2,9 @@ let socket;
 let memberId = null; // 이 사용자의 memberId 저장
 let onlineFriendMemberIdList = []; // 현재 온라인인 친구의 memberId 저장
 let currentChattingMemberId = null; // 현재 이 사용자가 보고 있는 채팅방의 상대 memberId 저장
+let currentViewingChatroomUuid = null; // 현재 이 사용자가 보고 있는 채팅방의 uuid 저장
+let messagesFromThisChatroom = []; // 현재 보고 있는 채팅방의 메시지 목록
+let hasNextChat = false; // 채팅 내역 조회를 위해, 다음 채팅내역이 존재하는지 여부 저장
 
 const loginStatus = document.getElementById("loginStatus");
 
@@ -146,6 +149,74 @@ function setupSocketListeners() {
     }
 
     // 채팅방 목록 내 li 요소 재정렬
+    reorderChatroomsByLastMsgTime();
+  });
+
+  // chat-message event listener
+  socket.on("chat-message", (response) => {
+    // 메시지가 온 채팅방이 현재 보고있는 채팅방인 경우
+    if (response.data.chatroomUuid === currentViewingChatroomUuid) {
+      // (#11-2) messagesFromThisChatroom array 업데이트
+      const { chatroomUuid, ...newMessage } = response.data;
+
+      messagesFromThisChatroom.push(newMessage);
+
+      console.log("============== messagesFromThisChatroom Updated ==============");
+      console.log(messagesFromThisChatroom);
+
+      // (#11-3) 채팅 메시지 요소 동적 생성
+      const messagesElement = document.getElementById("messages");
+      const li = document.createElement("li");
+      li.classList.add("message-item");
+      if (response.data.senderId === memberId) {
+        li.classList.add("mine");
+      }
+      li.innerHTML = `
+                                              <div class="message-content">
+                                                <img src="${response.data.senderProfileImg}" alt="Profile Image" width="30" height="30">
+                                                <div>
+                                                  <p class="sender-name">${response.data.senderName}</p>
+                                                  <p class="message-text">${response.data.message}</p>
+                                                  <p class="message-time">${new Date(response.data.createdAt).toLocaleString()}</p>
+                                                </div>
+                                              </div>
+                                            `;
+      messagesElement.appendChild(li);
+
+      // (#11-4) 8080에게 해당 채팅 메시지를 읽었음 요청 전송
+      readChatApi(currentViewingChatroomUuid, response.data.timestamp);
+    } else {
+      // 내가 보고있는 채팅방에서 온 메시지가 아닌 경우
+      // (#11-6) 해당 메시지의 전송자가 내가 아닌 경우에만 채팅방 목록 내의 읽지 않은 메시지 개수 업데이트
+      if (response.data.senderId != memberId) {
+        const chatroomItemNewCnt = document.querySelector(`.chatroom-item[data-chatroom-uuid="${response.data.chatroomUuid}"] p[data-new-count]`);
+        if (chatroomItemNewCnt) {
+          // 현재 텍스트 내용을 숫자로 변환하여 1 증가시킨 후 다시 설정
+          const currentCount = parseInt(chatroomItemNewCnt.textContent);
+          chatroomItemNewCnt.textContent = `${currentCount + 1}`;
+        } else {
+          console.error(`Could not find chatroom item with UUID ${response.data.chatroomUuid} to update new message count.`);
+        }
+      }
+    }
+
+    // (#11-7) 채팅방 목록 element 업데이트
+    // 채팅방 목록 내의 마지막 전송시각 업데이트
+    const chatroomItemLastTime = document.querySelector(`.chatroom-item[data-chatroom-uuid="${response.data.chatroomUuid}"] p[last-msg-time]`);
+    if (chatroomItemLastTime) {
+      chatroomItemLastTime.textContent = `${new Date(response.data.createdAt).toLocaleString()}`;
+    } else {
+      console.error(`Could not find chatroom item with UUID ${response.data.chatroomUuid} to update last msg time.`);
+    }
+
+    // 채팅방 목록 내의 마지막 메시지 업데이트
+    const chatroomItemLastMsg = document.querySelector(`.chatroom-item[data-chatroom-uuid="${response.data.chatroomUuid}"] p[last-msg-text]`);
+    if (chatroomItemLastMsg) {
+      chatroomItemLastMsg.textContent = response.data.message;
+    } else {
+      console.error(`Could not find chatroom item with UUID ${response.data.chatroomUuid} to update last msg text.`);
+    }
+    // 채팅방 목록 li 요소 재정렬
     reorderChatroomsByLastMsgTime();
   });
 }

--- a/socket/apis/chatApi.js
+++ b/socket/apis/chatApi.js
@@ -28,6 +28,29 @@ async function fetchChatroomUuid(socket) {
   }
 }
 
+async function postChatMessage(socket, chatroomUuid, message) {
+  const response = await axios.post(
+    `${API_SERVER_URL}/v1/chat/${chatroomUuid}`,
+    { message: message },
+    {
+      headers: {
+        Authorization: `Bearer ${socket.token}`,
+      },
+    }
+  );
+  if (response.data.isSuccess) {
+    return response.data.result;
+  } else {
+    if (["JWT400", "JWT401", "JWT404"].includes(response.data.code)) {
+      console.error("JWT token Error: ", response.data.message);
+      throw new JWTTokenError(`JWT token Error: ${response.data.message}`, response.data.code);
+    }
+    console.error("Failed to fetch chatroom uuid: ", response.data.message);
+    throw new Error(`Failed to fetch chatroom uuid: ${response.data.message}`);
+  }
+}
+
 module.exports = {
   fetchChatroomUuid,
+  postChatMessage,
 };

--- a/socket/emitters/chatEmitter.js
+++ b/socket/emitters/chatEmitter.js
@@ -1,0 +1,21 @@
+const formatResponse = require("../common/responseFormatter");
+
+/**
+ * chat message를 socket에 전달
+ * @param {*} socket
+ * @param {*} chatroomUuid
+ * @param {*} data
+ */
+function emitChatMessage(socket, chatroomUuid, data) {
+  data.chatroomUuid = chatroomUuid;
+
+  // uuid에 해당하는 room에 있는 socket 중 나를 제외한 socket에 broadcast
+  socket.broadcast.to("CHAT_" + chatroomUuid).emit("chat-message", formatResponse("chat-message", data));
+
+  // 내 socket에 message broadcast가 성공했음을 emit
+  socket.emit("my-message-broadcast-success", formatResponse("my-message-broadcast-success", data));
+}
+
+module.exports = {
+  emitChatMessage,
+};

--- a/socket/handlers/chat/chatHandler.js
+++ b/socket/handlers/chat/chatHandler.js
@@ -1,7 +1,40 @@
+const JWTTokenError = require("../../../common/JWTTokenError");
+
+const { emitError, emitJWTError } = require("../../emitters/errorEmitter");
+const { postChatMessage } = require("../../apis/chatApi");
+const { emitChatMessage } = require("../../emitters/chatEmitter");
 /**
  * socket event에 대한 listener
  * @param {*} socket
  */
-function setupChatListeners(socket) {}
+function setupChatListeners(socket) {
+  // chat-message event 발생 시, 8080서버에 채팅 등록 api 요청 및 해당 room에 event emit
+  socket.on("chat-message", (request) => {
+    const chatroomUuid = request.uuid;
+    const msg = request.message;
+    // uuid가 없는 경우 error event emit
+    if (!chatroomUuid) {
+      console.error("Fail listening chat-message event: chatroomUuid is missing");
+      emitError(socket, "Fail listening chat-message event: chatroomUuid is missing");
+    }
+
+    // (#10-2) 8080서버에 채팅 저장 api 요청
+    postChatMessage(socket, chatroomUuid, msg)
+      .then((response) => {
+        // (#10-3) 채팅 저장 정상 응답 받음
+        // (#10-4),(#10-5) 해당 채팅방의 상대 회원에게 chat-message emit, 내 socket에게 my-message-broadcast-success emit
+        emitChatMessage(socket, chatroomUuid, response);
+      })
+      .catch((error) => {
+        if (error instanceof JWTTokenError) {
+          console.error("JWT Token Error:", error.message);
+          emitJWTError(socket, error.code, error.message);
+        } else {
+          console.error("Error fetching friend list data:", error);
+          emitError(socket, error.message);
+        }
+      });
+  });
+}
 
 module.exports = { setupChatListeners };


### PR DESCRIPTION
## 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요. -->

## 🔍 변경사항
<!-- 이 PR로 인해 바뀌게 되는 것들을 목록으로 적어주세요. -->
- 클라이언트 채팅 폼 제출 시 chat-message event emit 추가
- 서버 chatHandler에 chat-message event listener 추가
- 서버 chatEmitter 추가
- 서버 ChatApi에 postChatMessage 메소드 추가
- 클라이언트 my-message-broadcast-success event listener 추가
- 클라이언트 chat-message event listener 추가

## ⏳ 작업 내용
- [x] 클라이언트 채팅 메시지 전송 emit
- [x]  3000서버 -> 8080서버 채팅 메시지 등록 api 요청
- [x]  chat-message broadcast & listener
- [x]  my-chat-message-broadcast-success emit & listener
- [x]  클라이언트 채팅방 읽음처리 api 요청

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
