### PR TITLE
[Feat/33] 채팅방 나가기, 시작하기 기능 구현 및 버그 수정

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -22,6 +22,27 @@ app.use(express.json());
 
 app.use(express.static(path.join(__dirname, "../public")));
 
+// 프로필 이미지 제공
+app.get("/:id", (req, res) => {
+  const id = req.params.id;
+  const options = {
+    root: path.join(__dirname, "../public", "img"),
+  };
+
+  // Ensure the ID is a valid number between 1 and 8
+  if (id >= 1 && id <= 8) {
+    const fileName = `profile_${id}.png`;
+    res.sendFile(fileName, options, (err) => {
+      if (err) {
+        console.error("Error sending file:", err);
+        res.status(500).send("Error sending file");
+      }
+    });
+  } else {
+    res.status(404).send("Profile image not found");
+  }
+});
+
 app.get("/", (req, res) => {
   res.send(`
     <!DOCTYPE html>

--- a/public/scripts/api.js
+++ b/public/scripts/api.js
@@ -176,3 +176,22 @@ async function startChatApi(memberId) {
     console.error("Error:", error);
   }
 }
+
+async function exitChatroomApi(chatroomUuid) {
+  try {
+    const jwtToken = localStorage.getItem("jwtToken");
+    const response = await fetch(`${API_SERVER_URL}/v1/chat/${chatroomUuid}/exit`, {
+      headers: {
+        Authorization: `Bearer ${jwtToken}`, // Include JWT token in header
+      },
+    });
+    const data = await response.json();
+    if (data.isSuccess && data.result) {
+      return data.result;
+    } else {
+      throw new Error("exitChatroomApi failed");
+    }
+  } catch (error) {
+    console.error("Error:", error);
+  }
+}

--- a/public/scripts/api.js
+++ b/public/scripts/api.js
@@ -154,3 +154,25 @@ async function getMessageApi(chatroomUuid, cursor) {
     console.error("Error:", error);
   }
 }
+
+async function startChatApi(memberId) {
+  try {
+    const jwtToken = localStorage.getItem("jwtToken");
+    const response = await fetch(`${API_SERVER_URL}/v1/chat/start`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${jwtToken}`, // Include JWT token in header
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ targetMemberId: memberId }),
+    });
+    const data = await response.json();
+    if (data.isSuccess && data.result) {
+      return data.result;
+    } else {
+      throw new Error("startChatApi failed");
+    }
+  } catch (error) {
+    console.error("Error:", error);
+  }
+}

--- a/public/scripts/api.js
+++ b/public/scripts/api.js
@@ -63,7 +63,7 @@ async function loginNodeApi() {
 async function getFriendListApi() {
   try {
     const jwtToken = localStorage.getItem("jwtToken");
-    const response = await fetch(`${API_SERVER_URL}/v1/member/friends`, {
+    const response = await fetch(`${API_SERVER_URL}/v1/friends`, {
       headers: {
         Authorization: `Bearer ${jwtToken}`, // Include JWT token in header
       },

--- a/public/scripts/eventListeners.js
+++ b/public/scripts/eventListeners.js
@@ -137,6 +137,19 @@ fetchFriendsButton.addEventListener("click", () => {
               chatroomHeader.innerHTML = `<img src="${result.memberProfileImg}" alt="Profile Image" width="30" height="30" style="vertical-align: middle;">${result.gameName}`;
               chatroomHeader.appendChild(statusElement);
 
+              // 채팅방 나가기 버튼 생성
+              const exitButton = document.createElement("button");
+              exitButton.textContent = "나가기";
+              exitButton.style.marginLeft = "10px";
+
+              // 채팅방 나가기 버튼 클릭 이벤트 리스너 추가
+              exitButton.addEventListener("click", () => {
+                exitChatroom(result.uuid);
+              });
+
+              // 헤더에 채팅방 나가기 버튼 추가
+              chatroomHeader.appendChild(exitButton);
+
               // 채팅방 목록에 읽지 않은 메시지 개수를 0으로 업데이트
               const chatroomItem = document.querySelector(`.chatroom-item[data-chatroom-uuid="${result.uuid}"] p[data-new-count]`);
               if (chatroomItem) {
@@ -314,6 +327,19 @@ function enterChatroom(chatroomUuid) {
       chatroomHeader.innerHTML = `<img src="${result.memberProfileImg}" alt="Profile Image" width="30" height="30" style="vertical-align: middle;">${result.gameName}`;
       chatroomHeader.appendChild(statusElement);
 
+      // 채팅방 나가기 버튼 생성
+      const exitButton = document.createElement("button");
+      exitButton.textContent = "나가기";
+      exitButton.style.marginLeft = "10px";
+
+      // 채팅방 나가기 버튼 클릭 이벤트 리스너 추가
+      exitButton.addEventListener("click", () => {
+        exitChatroom(chatroomUuid);
+      });
+
+      // 헤더에 채팅방 나가기 버튼 추가
+      chatroomHeader.appendChild(exitButton);
+
       // (#9-7) 채팅방 목록에 읽지 않은 메시지 개수를 0으로 업데이트
       const chatroomItem = document.querySelector(`.chatroom-item[data-chatroom-uuid="${chatroomUuid}"] p[data-new-count]`);
       if (chatroomItem) {
@@ -339,6 +365,40 @@ form.addEventListener("submit", (e) => {
     input.value = "";
   }
 });
+
+// 채팅방 퇴장 시
+function exitChatroom(chatroomUuid) {
+  console.log(`Exit chatroom with UUID: ${chatroomUuid}`);
+
+  exitChatroomApi(chatroomUuid).then(() => {
+    // chatroom 영역 초기화
+    // 기존 메시지 element 초기화
+    const messagesElement = document.getElementById("messages");
+    messagesElement.innerHTML = "";
+
+    // 채팅방 내부 헤더 초기화
+    const chatroomHeader = document.querySelector(".column.chatroom h2");
+    chatroomHeader.innerHTML = "채팅방";
+
+    // 채팅방 목록 영역에서 해당 채팅방 삭제
+    const chatroomItem = document.querySelector(`.chatroom-item[data-chatroom-uuid="${chatroomUuid}"]`);
+    if (chatroomItem) {
+      chatroomItem.remove();
+    } else {
+      console.log("chatroom delete not found: ", chatroomUuid);
+    }
+
+    // messagesFromThisChatroom array 초기화
+    messagesFromThisChatroom = null;
+
+    // hasNextChat 업데이트
+    hasNextChat = null;
+
+    // 현재 보고 있는 채팅방 uuid, 채팅 중인 memberId 초기화
+    currentViewingChatroomUuid = null;
+    currentChattingMemberId = null;
+  });
+}
 
 // 채팅방 내부에서 스크롤이 가장 위에 닿았을 때
 document.addEventListener("DOMContentLoaded", () => {

--- a/public/scripts/eventListeners.js
+++ b/public/scripts/eventListeners.js
@@ -76,6 +76,82 @@ fetchFriendsButton.addEventListener("click", () => {
                   <span>${friend.name}</span>
                 `;
         li.appendChild(statusElement);
+
+        // 해당 친구 부분 클릭 시, 친구와의 채팅방 시작 api 요청
+        li.addEventListener("click", () => {
+          startChatApi(friend.memberId)
+            .then((result) => {
+              // messagesFromThisChatroom array 초기화
+              messagesFromThisChatroom = result.chatMessageList.chatMessageDtoList;
+
+              console.log("============== fetch chat messages result ===============");
+              console.log(result.chatMessageList);
+
+              // hasNextChat 업데이트
+              hasNextChat = result.chatMessageList.has_next;
+
+              // 기존 메시지 element 초기화
+              const messagesElement = document.getElementById("messages");
+              const shouldScrollToBottom = messagesElement.scrollTop === messagesElement.scrollHeight - messagesElement.clientHeight;
+
+              messagesElement.innerHTML = "";
+
+              // messagesFromThisChatroom의 각 messgae 요소 렌더링
+              messagesFromThisChatroom.forEach((message) => {
+                const li = document.createElement("li");
+                li.classList.add("message-item");
+                if (message.senderId === memberId) {
+                  li.classList.add("mine");
+                }
+                li.innerHTML = `
+                    <div class="message-content">
+                      <img src="${message.senderProfileImg}" alt="Profile Image" width="30" height="30">
+                      <div>
+                        <p class="sender-name">${message.senderName}</p>
+                        <p class="message-text">${message.message}</p>
+                        <p class="message-time">${new Date(message.createdAt).toLocaleString()}</p>
+                      </div>
+                    </div>
+                  `;
+                messagesElement.appendChild(li);
+              });
+
+              // Scroll to bottom if was already at bottom before fetching new messages or on initial load
+              if (shouldScrollToBottom || messagesElement.children.length === 0) {
+                messagesElement.scrollTop = messagesElement.scrollHeight;
+              }
+
+              // 채팅방 내부 헤더 렌더링
+              const chatroomHeader = document.querySelector(".column.chatroom h2");
+
+              // 상대 회원이 현재 온라인인 친구 목록에 있는지 여부를 따져서 상태 text 설정
+              const isOnline = onlineFriendMemberIdList.includes(result.memberId);
+              const statusText = isOnline ? "online" : "offline";
+
+              // 상태 element에 class 부여
+              const statusElement = document.createElement("span");
+              statusElement.textContent = `(${statusText})`;
+              statusElement.classList.add(isOnline ? "online" : "offline");
+
+              // 헤더의 profile image, name, 상태 element 업데이트
+              chatroomHeader.innerHTML = `<img src="${result.memberProfileImg}" alt="Profile Image" width="30" height="30" style="vertical-align: middle;">${result.gameName}`;
+              chatroomHeader.appendChild(statusElement);
+
+              // 채팅방 목록에 읽지 않은 메시지 개수를 0으로 업데이트
+              const chatroomItem = document.querySelector(`.chatroom-item[data-chatroom-uuid="${result.uuid}"] p[data-new-count]`);
+              if (chatroomItem) {
+                chatroomItem.textContent = "0";
+              } else {
+                console.error(`Could not find chatroom item with UUID ${result.uuid} to update new count.`);
+              }
+
+              // 현재 보고 있는 채팅방 uuid, 채팅 중인 memberId 업데이트
+              currentViewingChatroomUuid = result.uuid;
+              currentChattingMemberId = result.memberId;
+            })
+            .catch((error) => console.error("Error:", error));
+        });
+
         friendsElement.appendChild(li);
       });
     }

--- a/socket/apis/friendApi.js
+++ b/socket/apis/friendApi.js
@@ -5,13 +5,13 @@ const config = require("../../common/config");
 const API_SERVER_URL = config.apiServerUrl;
 
 /**
- * 현재 회원이 속한 채팅방의 uuid 목록을 요청하는 메소드
+ * 회원의 친구 목록을 요청하는 메소드
  * @param {*} socket
  * @returns
  */
 async function fetchFriends(socket) {
   try {
-    const response = await axios.get(`${API_SERVER_URL}/v1/member/friends`, {
+    const response = await axios.get(`${API_SERVER_URL}/v1/friends`, {
       headers: {
         Authorization: `Bearer ${socket.token}`, // Include JWT token in header
       },


### PR DESCRIPTION
## 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요. -->
채팅방 나가기, 시작하기 기능 구현 및 버그 수정

## 🔍 변경사항
<!-- 이 PR로 인해 바뀌게 되는 것들을 목록으로 적어주세요. -->
- 프로필 이미지 static file 제공 코드 추가
- 친구 목록 조회 API endpoint 변경된 것 반영
- 친구 목록 li 마다 클릭 시 해당 친구와의 채팅방 시작되도록 api 연동 및 화면 렌더링
- 채팅방 내부 헤더에 채팅방 나가기 버튼 추가 및 채팅방 나가기 api 연동
- 채팅방 시작 후 첫 메시지 전송 시 채팅방 목록에 해당 채팅방 li 추가
- 채팅방 퇴장 시 채팅방 목록에 해당 채팅방 li 삭제 및 전역변수 초기화

## ⏳ 작업 내용
- [x] 프로필 이미지 static file 제공 코드 추가
- [x] 친구 목록 조회 API endpoint 변경된 것 반영
- [x] 채팅방 시작하기, 채팅방 나가기 api 요청 코드 구현
- [x] 채팅방 시작 시 관련 화면 렌더링 코드 구현
- [x] 채팅방 퇴장 시 관련 화면 렌더링 코드 구현

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
