### PR TITLE
[Feat/39] 채팅방 API 변경 반영 및 친구목록, 채팅방 입장/시작 관련 로직 추가

### DIFF
--- a/public/scripts/api.js
+++ b/public/scripts/api.js
@@ -121,6 +121,7 @@ async function readChatApi(chatroomUuid, timestamp) {
   try {
     const jwtToken = localStorage.getItem("jwtToken");
     const response = await fetch(`${API_SERVER_URL}/v1/chat/${chatroomUuid}/read?timestamp=${timestamp}`, {
+      method: "PATCH", // PATCH 메서드로 요청
       headers: {
         Authorization: `Bearer ${jwtToken}`, // Include JWT token in header
       },
@@ -181,6 +182,7 @@ async function exitChatroomApi(chatroomUuid) {
   try {
     const jwtToken = localStorage.getItem("jwtToken");
     const response = await fetch(`${API_SERVER_URL}/v1/chat/${chatroomUuid}/exit`, {
+      method: "PATCH", // PATCH 메서드로 요청
       headers: {
         Authorization: `Bearer ${jwtToken}`, // Include JWT token in header
       },

--- a/public/scripts/api.js
+++ b/public/scripts/api.js
@@ -197,3 +197,43 @@ async function exitChatroomApi(chatroomUuid) {
     console.error("Error:", error);
   }
 }
+
+async function starFriendApi(memberId) {
+  try {
+    const jwtToken = localStorage.getItem("jwtToken");
+    const response = await fetch(`${API_SERVER_URL}/v1/friends/${memberId}/star`, {
+      method: "PATCH", // PATCH 메서드로 요청
+      headers: {
+        Authorization: `Bearer ${jwtToken}`, // Include JWT token in header
+      },
+    });
+    const data = await response.json();
+    if (data.isSuccess && data.result) {
+      return data.result;
+    } else {
+      throw new Error("starFriendApi failed");
+    }
+  } catch (error) {
+    console.error("Error:", error);
+  }
+}
+
+async function unstarFriendApi(memberId) {
+  try {
+    const jwtToken = localStorage.getItem("jwtToken");
+    const response = await fetch(`${API_SERVER_URL}/v1/friends/${memberId}/star`, {
+      method: "DELETE", // DELETE 메서드로 요청
+      headers: {
+        Authorization: `Bearer ${jwtToken}`, // Include JWT token in header
+      },
+    });
+    const data = await response.json();
+    if (data.isSuccess && data.result) {
+      return data.result;
+    } else {
+      throw new Error("unstarFriendApi failed");
+    }
+  } catch (error) {
+    console.error("Error:", error);
+  }
+}

--- a/public/scripts/eventListeners.js
+++ b/public/scripts/eventListeners.js
@@ -71,14 +71,32 @@ fetchFriendsButton.addEventListener("click", () => {
         statusElement.classList.add(isOnline ? "online" : "offline");
 
         li.setAttribute("data-member-id", friend.memberId);
-        li.innerHTML = `
-                  <img src="${friend.memberProfileImg}" alt="${friend.name}'s profile picture" width="30" height="30">
-                  <span>${friend.name}</span>
-                `;
+
+        // 사용자 정보를 담는 div 생성
+        const userInfoDiv = document.createElement("div");
+        userInfoDiv.className = "user-info"; // CSS 클래스 추가
+        userInfoDiv.innerHTML = `
+                <img src="${friend.memberProfileImg}" alt="${friend.name}'s profile picture" width="30" height="30">
+                <span>${friend.name}</span>
+            `;
+        li.appendChild(userInfoDiv);
         li.appendChild(statusElement);
 
+        // 별 아이콘 추가
+        const star = document.createElement("span");
+        star.className = "star";
+        star.innerHTML = "☆";
+
+        // liked가 true인 경우 보라색으로 설정
+        if (friend.liked) {
+          star.classList.add("liked");
+        }
+
+        // li 요소에 별 아이콘 추가
+        li.appendChild(star);
+
         // 해당 친구 부분 클릭 시, 친구와의 채팅방 시작 api 요청
-        li.addEventListener("click", () => {
+        userInfoDiv.addEventListener("click", () => {
           startChatApi(friend.memberId)
             .then((result) => {
               // messagesFromThisChatroom array 초기화

--- a/public/scripts/eventListeners.js
+++ b/public/scripts/eventListeners.js
@@ -173,6 +173,26 @@ fetchFriendsButton.addEventListener("click", () => {
             .catch((error) => console.error("Error:", error));
         });
 
+        // 별 아이콘 클릭 시, 해당 친구 즐겨찾기 설정/해제 요청 전송
+        star.addEventListener("click", () => {
+          // liked 클래스가 있는지 확인
+          if (star.classList.contains("liked")) {
+            // 즐겨찾기 해제 api 요청
+            unstarFriendApi(friend.memberId).then((result) => {
+              // liked 상태 변경
+              star.classList.remove("liked");
+              console.log("즐겨찾기 해제 성공, memberId: ", friend.memberId);
+            });
+          } else {
+            // 즐겨찾기 설정 api 요청
+            starFriendApi(friend.memberId).then((result) => {
+              // liked 상태 변경
+              star.classList.add("liked");
+              console.log("즐겨찾기 설정 성공, memberId: ", friend.memberId);
+            });
+          }
+        });
+
         friendsElement.appendChild(li);
       });
     }

--- a/public/scripts/eventListeners.js
+++ b/public/scripts/eventListeners.js
@@ -103,7 +103,7 @@ fetchFriendsButton.addEventListener("click", () => {
               messagesFromThisChatroom = result.chatMessageList.chatMessageDtoList;
 
               console.log("============== fetch chat messages result ===============");
-              console.log(result.chatMessageList);
+              console.log(result.chatMessageList.chatMessageDtoList);
 
               // hasNextChat 업데이트
               hasNextChat = result.chatMessageList.has_next;
@@ -142,21 +142,26 @@ fetchFriendsButton.addEventListener("click", () => {
               // 채팅방 내부 헤더 렌더링
               const chatroomHeader = document.querySelector(".column.chatroom h2");
 
-              // 상대 회원이 현재 온라인인 친구 목록에 있는지 여부를 따져서 상태 text 설정
-              const isOnline = onlineFriendMemberIdList.includes(result.memberId);
-              const statusText = isOnline ? "online" : "offline";
-
-              // 상태 element에 class 부여
-              const statusElement = document.createElement("span");
-              statusElement.textContent = `(${statusText})`;
-              statusElement.classList.add(isOnline ? "online" : "offline");
-
-              // 헤더의 profile image, name, 상태 element 업데이트
+              // 헤더의 profile image, name 업데이트
               chatroomHeader.innerHTML = `<img src="${result.memberProfileImg}" alt="Profile Image" width="30" height="30" style="vertical-align: middle;">${result.gameName}`;
-              chatroomHeader.appendChild(statusElement);
 
-              // 채팅방 내부 메뉴 버튼 생성
-              createChatroomMenuButton(true);
+              // 상대 회원과 내가 친구 관계인 경우에만
+              if (result.friend) {
+                // 상대 회원이 현재 온라인인 친구 목록에 있는지 여부를 따져서 상태 text 설정
+                const isOnline = onlineFriendMemberIdList.includes(result.memberId);
+                const statusText = isOnline ? "online" : "offline";
+
+                // 상태 element에 class 부여
+                const statusElement = document.createElement("span");
+                statusElement.textContent = `(${statusText})`;
+                statusElement.classList.add(isOnline ? "online" : "offline");
+
+                // 채팅방 헤더에 상태 element 추가
+                chatroomHeader.appendChild(statusElement);
+              }
+
+              // 채팅방 내부 헤더 메뉴 버튼 생성
+              createChatroomMenuButton(result.friend);
 
               // 채팅방 목록에 읽지 않은 메시지 개수를 0으로 업데이트
               const chatroomItem = document.querySelector(`.chatroom-item[data-chatroom-uuid="${result.uuid}"] p[data-new-count]`);
@@ -169,6 +174,29 @@ fetchFriendsButton.addEventListener("click", () => {
               // 현재 보고 있는 채팅방 uuid, 채팅 중인 memberId 업데이트
               currentViewingChatroomUuid = result.uuid;
               currentChattingMemberId = result.memberId;
+
+              // 채팅 전송 폼 부분 렌더링
+              // chat-form 부분 추출
+              const chatForm = document.querySelector(".chat-form");
+              const inputField = chatForm.querySelector("input");
+              const sendButton = chatForm.querySelector("button");
+
+              // 상대가 나를 차단한 경우, 채팅 전송 불가하도록 막기
+              if (result.blocked) {
+                // input 필드에 텍스트 설정
+                inputField.value = "대화를 보낼 수 없는 상대입니다.";
+                inputField.disabled = true; // 입력 필드 비활성화
+
+                // 버튼 클릭(폼 전송) 불가 처리
+                sendButton.disabled = true; // 버튼 비활성화
+              } else {
+                // input 필드에 텍스트 초기화
+                inputField.value = "";
+                inputField.disabled = false; // 입력 필드 활성화
+
+                // 버튼 클릭(폼 전송) 가능 처리
+                sendButton.disabled = false; // 버튼 활성화
+              }
             })
             .catch((error) => console.error("Error:", error));
         });
@@ -303,7 +331,7 @@ function enterChatroom(chatroomUuid) {
       messagesFromThisChatroom = result.chatMessageList.chatMessageDtoList;
 
       console.log("============== fetch chat messages result ===============");
-      console.log(result.chatMessageList);
+      console.log(result.chatMessageList.chatMessageDtoList);
 
       // (#9-4) hasNextChat 업데이트
       hasNextChat = result.chatMessageList.has_next;
@@ -342,22 +370,26 @@ function enterChatroom(chatroomUuid) {
       // (#9-6) 채팅방 내부 헤더 렌더링
       const chatroomHeader = document.querySelector(".column.chatroom h2");
 
-      // 상대 회원이 현재 온라인인 친구 목록에 있는지 여부를 따져서 상태 text 설정
-      const isOnline = onlineFriendMemberIdList.includes(result.memberId);
-      const statusText = isOnline ? "online" : "offline";
-
-      // 상태 element에 class 부여
-      const statusElement = document.createElement("span");
-      statusElement.textContent = `(${statusText})`;
-      statusElement.classList.add(isOnline ? "online" : "offline");
-
-      // 헤더의 profile image, name, 상태 element 업데이트
+      // 헤더의 profile image, name 업데이트
       chatroomHeader.innerHTML = `<img src="${result.memberProfileImg}" alt="Profile Image" width="30" height="30" style="vertical-align: middle;">${result.gameName}`;
-      chatroomHeader.appendChild(statusElement);
 
-      // 채팅방 내부 메뉴 버튼 생성
-      // isFriend 여부는 result에서 추출해서 파라미터로 담아줘야 함, 지금은 일단 true라고 가정
-      createChatroomMenuButton(true);
+      // 상대 회원과 내가 친구 관계인 경우에만
+      if (result.friend) {
+        // 상대 회원이 현재 온라인인 친구 목록에 있는지 여부를 따져서 상태 text 설정
+        const isOnline = onlineFriendMemberIdList.includes(result.memberId);
+        const statusText = isOnline ? "online" : "offline";
+
+        // 상태 element에 class 부여
+        const statusElement = document.createElement("span");
+        statusElement.textContent = `(${statusText})`;
+        statusElement.classList.add(isOnline ? "online" : "offline");
+
+        // 채팅방 헤더에 상태 element 추가
+        chatroomHeader.appendChild(statusElement);
+      }
+
+      // 채팅방 내부 헤더 메뉴 버튼 생성
+      createChatroomMenuButton(result.friend);
 
       // (#9-7) 채팅방 목록에 읽지 않은 메시지 개수를 0으로 업데이트
       const chatroomItem = document.querySelector(`.chatroom-item[data-chatroom-uuid="${chatroomUuid}"] p[data-new-count]`);
@@ -370,6 +402,29 @@ function enterChatroom(chatroomUuid) {
       // (#9-8) 현재 보고 있는 채팅방 uuid, 채팅 중인 memberId 업데이트
       currentViewingChatroomUuid = chatroomUuid;
       currentChattingMemberId = result.memberId;
+
+      // 채팅 전송 폼 부분 렌더링
+      // chat-form 부분 추출
+      const chatForm = document.querySelector(".chat-form");
+      const inputField = chatForm.querySelector("input");
+      const sendButton = chatForm.querySelector("button");
+
+      // 상대가 나를 차단한 경우, 채팅 전송 불가하도록 막기
+      if (result.blocked) {
+        // input 필드에 텍스트 설정
+        inputField.value = "대화를 보낼 수 없는 상대입니다.";
+        inputField.disabled = true; // 입력 필드 비활성화
+
+        // 버튼 클릭(폼 전송) 불가 처리
+        sendButton.disabled = true; // 버튼 비활성화
+      } else {
+        // input 필드에 텍스트 초기화
+        inputField.value = "";
+        inputField.disabled = false; // 입력 필드 활성화
+
+        // 버튼 클릭(폼 전송) 가능 처리
+        sendButton.disabled = false; // 버튼 활성화
+      }
     }
   });
 }

--- a/public/scripts/socket.js
+++ b/public/scripts/socket.js
@@ -172,6 +172,15 @@ function setupSocketListeners() {
         `;
               chatroomListElement.appendChild(li);
 
+              // 새로 생성한 채팅방 목록 요소의 채팅방 입장 버튼에 eventListener 추가
+              const enterChatroomButtons = document.querySelectorAll(".enter-chatroom-btn");
+              enterChatroomButtons.forEach((button) => {
+                button.addEventListener("click", (event) => {
+                  const chatroomUuid = event.target.getAttribute("data-chatroom-uuid");
+                  enterChatroom(chatroomUuid);
+                });
+              });
+
               // 채팅방 목록 내 li 요소 재정렬
               reorderChatroomsByLastMsgTime();
             }

--- a/public/styles.css
+++ b/public/styles.css
@@ -164,10 +164,6 @@ p[data-new-count] {
   border-bottom: none; /* Remove border from the last item */
 }
 
-#friendsList img {
-  margin-right: 10px; /* Add space between the image and the text */
-}
-
 #loginStatus {
   color: white;
 }
@@ -335,4 +331,27 @@ p[data-new-count] {
 
 .menu-item:last-child {
   border-bottom: none;
+}
+
+/* 친구 목록 즐겨찾기 */
+.star {
+  font-size: 24px;
+  color: gray;
+  cursor: pointer;
+  margin-left: auto;
+  font-weight: bold;
+}
+
+.star.liked {
+  color: #6200ea; /* 보라색 */
+}
+
+.user-info {
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+}
+
+.user-info img {
+  margin-right: 10px;
 }


### PR DESCRIPTION
## 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요. -->

## 🔍 변경사항
<!-- 이 PR로 인해 바뀌게 되는 것들을 목록으로 적어주세요. -->
- 채팅 읽음 처리 API http 메소드 변경 반영 (GET -> PATCH)
- 채팅방 나가기 API http 메소드 변경 반영 (GET -> PATCH)
- 채팅방 입장/시작 시, 상대가 나를 차단한 경우 메시지 전송 불가하도록 제한 추가
- 채팅방 입장/시작 시, 상대와 내가 친구인지 여부에 따른 메뉴 팝업 버튼 생성
- 채팅방 입장/시작 시, 상대와 내가 친구관계일 때만 채팅방 헤더에 온라인 여부 표시되도록 로직 추가
- 친구 목록에 즐겨찾기 여부 표시 추가
- 친구 목록에서 별 아이콘 클릭 시 즐겨찾기 설정/해제 API 연동

## ⏳ 작업 내용
- [x] 채팅 읽음 처리 API http 메소드 변경 반영 (GET -> PATCH)
- [x] 채팅방 나가기 API http 메소드 변경 반영 (GET -> PATCH)
- [x] 채팅방 입장/시작 시, 상대가 나를 차단한 경우 메시지 전송 불가하도록 화면 추가
- [x] 채팅방 입장/시작 시, 상대와 내가 친구인지 여부에 따른 메뉴 팝업 버튼 생성
- [x] 채팅방 입장/시작 시, 상대와 내가 친구관계일 때만 채팅방 헤더에 온라인 여부 표시되도록
- [x] 친구 목록에 즐겨찾기 여부 표시 추가
- [x] 친구 목록에서 별 아이콘 클릭 시 즐겨찾기 설정/해제 API 연동

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
