### PR TITLE
[Feat/47] 채팅 시스템 메시지 기능 구현

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -66,7 +66,7 @@ app.get("/", (req, res) => {
               <div id="boardIdPopup" class="popup">
                 <div class="popup-content">
                 <form id="boardIdForm">
-                    <label for="boardIdInput">말 걸어보기 게시글 ID 입력</label>
+                    <label for="boardIdInput">채팅 시작할 게시글 ID 입력</label>
                     <input type="text" id="boardIdInput" name="boardId" placeholder="Enter board ID" />
                     <button type="submit">제출</button>
                     <button type="button" id="closePopupButton">취소</button>

--- a/app/app.js
+++ b/app/app.js
@@ -62,6 +62,7 @@ app.get("/", (req, res) => {
               <button id="loginButton">Login</button>
               <button id="logoutButton">Logout</button>
               <button id="boardTestButton">게시글 말 걸어보기</button>
+              <button id="matchingTestButton">매칭 채팅방 시작</button>
               <!-- 게시판 ID 입력 폼을 위한 팝업 추가 -->
               <div id="boardIdPopup" class="popup">
                 <div class="popup-content">
@@ -69,10 +70,23 @@ app.get("/", (req, res) => {
                     <label for="boardIdInput">채팅 시작할 게시글 ID 입력</label>
                     <input type="text" id="boardIdInput" name="boardId" placeholder="Enter board ID" />
                     <button type="submit">제출</button>
-                    <button type="button" id="closePopupButton">취소</button>
+                    <button type="button" id="closeBoardIdPopupButton">취소</button>
                   </form>
                 </div>
               </div>
+              <!-- 매칭 상대 회원 ID 입력 폼을 위한 팝업 추가 -->
+              <div id="matchingMemberIdPopup" class="popup">
+                <div class="popup-content">
+                <form id="mathingMemberIdForm">
+                    <label for="boardIdInput">매칭 시킬 회원 ID 입력</label>
+                    <input type="text" id="mathingMemberIdInput" name="mathingMemberId" placeholder="Enter member ID" />
+                    <button type="submit">제출</button>
+                    <button type="button" id="closeMatchingMemberIdPopupButton">취소</button>
+                  </form>
+                </div>
+              </div>
+
+
             </div>
             <div>
               <p id="loginStatus">You are not Login User</p>

--- a/app/app.js
+++ b/app/app.js
@@ -61,6 +61,18 @@ app.get("/", (req, res) => {
               <input id="userPw" type="string" placeholder="Enter your Pw" />
               <button id="loginButton">Login</button>
               <button id="logoutButton">Logout</button>
+              <button id="boardTestButton">게시글 말 걸어보기</button>
+              <!-- 게시판 ID 입력 폼을 위한 팝업 추가 -->
+              <div id="boardIdPopup" class="popup">
+                <div class="popup-content">
+                <form id="boardIdForm">
+                    <label for="boardIdInput">말 걸어보기 게시글 ID 입력</label>
+                    <input type="text" id="boardIdInput" name="boardId" placeholder="Enter board ID" />
+                    <button type="submit">제출</button>
+                    <button type="button" id="closePopupButton">취소</button>
+                  </form>
+                </div>
+              </div>
             </div>
             <div>
               <p id="loginStatus">You are not Login User</p>
@@ -78,7 +90,7 @@ app.get("/", (req, res) => {
             <div id="notificationItems">
               <div id="receivedNotifications" class="notification-type"></div>
               <div id="friendRequestNotifications" class="notification-type" style="display: none;"></div>
-            </div>
+            </div>  
           </div>
         </div>
           <div class="content">

--- a/public/scripts/api.js
+++ b/public/scripts/api.js
@@ -176,6 +176,26 @@ async function startChatByMemberIdApi(memberId) {
   }
 }
 
+async function startChatByBoardIdApi(boardId) {
+  try {
+    const jwtToken = localStorage.getItem("jwtToken");
+    const response = await fetch(`${API_SERVER_URL}/v1/chat/start/board/${boardId}`, {
+      headers: {
+        Authorization: `Bearer ${jwtToken}`, // Include JWT token in header
+        "Content-Type": "application/json",
+      },
+    });
+    const data = await response.json();
+    if (data.isSuccess && data.result) {
+      return data.result;
+    } else {
+      throw new Error("startChatByBoardIdApi failed");
+    }
+  } catch (error) {
+    console.error("Error:", error);
+  }
+}
+
 async function exitChatroomApi(chatroomUuid) {
   try {
     const jwtToken = localStorage.getItem("jwtToken");

--- a/public/scripts/api.js
+++ b/public/scripts/api.js
@@ -159,13 +159,11 @@ async function getMessageApi(chatroomUuid, cursor) {
 async function startChatApi(memberId) {
   try {
     const jwtToken = localStorage.getItem("jwtToken");
-    const response = await fetch(`${API_SERVER_URL}/v1/chat/start`, {
-      method: "POST",
+    const response = await fetch(`${API_SERVER_URL}/v1/chat/start/member/${memberId}`, {
       headers: {
         Authorization: `Bearer ${jwtToken}`, // Include JWT token in header
         "Content-Type": "application/json",
       },
-      body: JSON.stringify({ targetMemberId: memberId }),
     });
     const data = await response.json();
     if (data.isSuccess && data.result) {

--- a/public/scripts/api.js
+++ b/public/scripts/api.js
@@ -156,7 +156,7 @@ async function getMessageApi(chatroomUuid, cursor) {
   }
 }
 
-async function startChatApi(memberId) {
+async function startChatByMemberIdApi(memberId) {
   try {
     const jwtToken = localStorage.getItem("jwtToken");
     const response = await fetch(`${API_SERVER_URL}/v1/chat/start/member/${memberId}`, {
@@ -169,7 +169,7 @@ async function startChatApi(memberId) {
     if (data.isSuccess && data.result) {
       return data.result;
     } else {
-      throw new Error("startChatApi failed");
+      throw new Error("startChatByMemberIdApi failed");
     }
   } catch (error) {
     console.error("Error:", error);

--- a/public/scripts/eventListeners.js
+++ b/public/scripts/eventListeners.js
@@ -504,6 +504,7 @@ document.getElementById("mathingMemberIdForm").addEventListener("submit", (event
   document.getElementById("matchingMemberIdPopup").style.display = "none";
 
   const matchingMemberId = document.getElementById("mathingMemberIdInput").value;
+  socket.emit("test-matching-request", { matchingMemberId: matchingMemberId });
 });
 
 // 채팅방 퇴장 시

--- a/public/scripts/eventListeners.js
+++ b/public/scripts/eventListeners.js
@@ -399,6 +399,24 @@ function addNotification(type, message, time, isRead) {
   notificationContainer.appendChild(div);
 }
 
+// 게시판 말걸어보기 테스트 버튼 클릭 시
+document.getElementById("boardTestButton").addEventListener("click", () => {
+  document.getElementById("boardIdPopup").style.display = "block";
+});
+
+// 게시판 말걸어보기 팝업 닫기 버튼 클릭 시
+document.getElementById("closePopupButton").addEventListener("click", () => {
+  document.getElementById("boardIdPopup").style.display = "none";
+});
+
+// 게시판 말걸어보기 팝업 제출 버튼 클릭 시
+document.getElementById("boardIdForm").addEventListener("submit", (event) => {
+  event.preventDefault(); // 기본 제출 동작 방지
+  const boardId = document.getElementById("boardIdInput").value;
+  alert(`Board ID: ${boardId} 제출 완료`);
+  document.getElementById("boardIdPopup").style.display = "none";
+});
+
 // 채팅방 퇴장 시
 function exitChatroom(chatroomUuid) {
   console.log(`Exit chatroom with UUID: ${chatroomUuid}`);

--- a/public/scripts/eventListeners.js
+++ b/public/scripts/eventListeners.js
@@ -579,10 +579,30 @@ function renderChatroomDiv(result) {
   result.chatMessageList.chatMessageDtoList.forEach((message) => {
     const li = document.createElement("li");
     li.classList.add("message-item");
-    if (message.senderId === memberId) {
-      li.classList.add("mine");
-    }
-    li.innerHTML = `
+
+    if (message.senderId === 0) {
+      // 해당 메시지가 시스템 메시지인 경우
+
+      li.classList.add("system-message");
+      if (message.boardId) {
+        li.setAttribute("data-board-id", message.boardId); // 특정 글로 이동해야 하는 경우, boardId 저장
+        li.addEventListener("click", function () {
+          // 클릭 시 alert 창 띄우기 (원래는 해당 boardId로 게시글 조회 API로 넘어가야 함)
+          alert(`게시판 글 조회 페이지로 이동, board id: ${message.boardId}`);
+        });
+      }
+
+      li.innerHTML = `
+                    <div class="message-content" style = "cursor: pointer;">
+                        <p class="message-text">${message.message}</p>
+                    </div>
+                  `;
+    } else {
+      // 시스템 메시지가 아닌 경우
+      if (message.senderId === memberId) {
+        li.classList.add("mine");
+      }
+      li.innerHTML = `
                     <div class="message-content">
                       <img src="${message.senderProfileImg}" alt="Profile Image" width="30" height="30">
                       <div>
@@ -592,6 +612,7 @@ function renderChatroomDiv(result) {
                       </div>
                     </div>
                   `;
+    }
     messagesElement.appendChild(li);
   });
 

--- a/public/scripts/eventListeners.js
+++ b/public/scripts/eventListeners.js
@@ -410,11 +410,59 @@ document.getElementById("closePopupButton").addEventListener("click", () => {
 });
 
 // 게시판 말걸어보기 팝업 제출 버튼 클릭 시
+// 게시글을 통한 채팅방 시작
 document.getElementById("boardIdForm").addEventListener("submit", (event) => {
   event.preventDefault(); // 기본 제출 동작 방지
-  const boardId = document.getElementById("boardIdInput").value;
-  alert(`Board ID: ${boardId} 제출 완료`);
   document.getElementById("boardIdPopup").style.display = "none";
+
+  const boardId = document.getElementById("boardIdInput").value;
+  // 특정 글을 통한 채팅방 시작 API 요청
+  startChatByBoardIdApi(boardId).then((result) => {
+    // 채팅방 시작 API 정상 응답 받음
+    // messagesFromThisChatroom array 초기화
+    messagesFromThisChatroom = result.chatMessageList.chatMessageDtoList;
+
+    // messagesFromThisChatroom 맨 뒤에 시스템 메시지 임의로 추가 (프론트 화면에서 보여지기 위함)
+    if (result.system.flag === 1) {
+      const systemMessage = {
+        senderId: 0,
+        senderName: "SYSTEM",
+        senderProfileImg: 0,
+        message: "상대방이 게시한 글을 보고 말을 걸었어요. 대화를 시작해보세요~",
+        createdAt: null,
+        timestamp: null,
+        boardId: result.system.boardId,
+      };
+      messagesFromThisChatroom.push(systemMessage);
+    } else {
+      const systemMessage = {
+        senderId: 0,
+        senderName: "SYSTEM",
+        senderProfileImg: 0,
+        message: "상대방이 게시한 글을 보고 말을 걸었어요.",
+        createdAt: null,
+        timestamp: null,
+        boardId: result.system.boardId,
+      };
+      messagesFromThisChatroom.push(systemMessage);
+    }
+
+    console.log("============== fetch chat messages result ===============");
+    console.log(result.chatMessageList.chatMessageDtoList);
+
+    // hasNextChat 업데이트
+    hasNextChat = result.chatMessageList.has_next;
+
+    // 현재 보고 있는 채팅방 uuid, 채팅 중인 memberId 업데이트
+    currentViewingChatroomUuid = result.uuid;
+    currentChattingMemberId = result.memberId;
+
+    // systemFlag 초기화
+    currentSystemFlag = result.system;
+    console.log("currentSystemFlag: ", currentSystemFlag);
+
+    renderChatroomDiv(result);
+  });
 });
 
 // 채팅방 퇴장 시

--- a/public/scripts/eventListeners.js
+++ b/public/scripts/eventListeners.js
@@ -318,19 +318,39 @@ function fetchOlderMessages() {
       olderMessages.reverse().forEach((message) => {
         const li = document.createElement("li");
         li.classList.add("message-item");
-        if (message.senderId === memberId) {
-          li.classList.add("mine");
-        }
-        li.innerHTML = `
-                  <div class="message-content">
-                    <img src="${message.senderProfileImg}" alt="Profile Image" width="30" height="30">
-                    <div>
-                      <p class="sender-name">${message.senderName}</p>
-                      <p class="message-text">${message.message}</p>
-                      <p class="message-time">${new Date(message.createdAt).toLocaleString()}</p>
+        if (message.senderId === 0) {
+          // 해당 메시지가 시스템 메시지인 경우
+
+          li.classList.add("system-message");
+          if (message.boardId) {
+            li.setAttribute("data-board-id", message.boardId); // 특정 글로 이동해야 하는 경우, boardId 저장
+            li.addEventListener("click", function () {
+              // 클릭 시 alert 창 띄우기 (원래는 해당 boardId로 게시글 조회 API로 넘어가야 함)
+              alert(`게시판 글 조회 페이지로 이동, board id: ${message.boardId}`);
+            });
+          }
+
+          li.innerHTML = `
+                    <div class="message-content" style = "cursor: pointer;">
+                        <p class="message-text">${message.message}</p>
                     </div>
-                  </div>
-                `;
+                  `;
+        } else {
+          // 시스템 메시지가 아닌 경우
+          if (message.senderId === memberId) {
+            li.classList.add("mine");
+          }
+          li.innerHTML = `
+                    <div class="message-content">
+                      <img src="${message.senderProfileImg}" alt="Profile Image" width="30" height="30">
+                      <div>
+                        <p class="sender-name">${message.senderName}</p>
+                        <p class="message-text">${message.message}</p>
+                        <p class="message-time">${new Date(message.createdAt).toLocaleString()}</p>
+                      </div>
+                    </div>
+                  `;
+        }
         messagesElement.prepend(li);
       });
 
@@ -346,6 +366,8 @@ form.addEventListener("submit", (e) => {
   if (input.value) {
     const msg = input.value;
     // (#10-1) "chat-message" event emit
+    console.log("CHAT-MESSAGE EVENT EMIT ====== currentSystemFlag: ", currentSystemFlag);
+
     if (currentSystemFlag) {
       // 보내야 할 systemFlag가 있는 경우
       socket.emit("chat-message", { uuid: currentViewingChatroomUuid, message: msg, system: currentSystemFlag });

--- a/public/scripts/eventListeners.js
+++ b/public/scripts/eventListeners.js
@@ -427,7 +427,7 @@ document.getElementById("boardTestButton").addEventListener("click", () => {
 });
 
 // 게시판 말걸어보기 팝업 닫기 버튼 클릭 시
-document.getElementById("closePopupButton").addEventListener("click", () => {
+document.getElementById("closeBoardIdPopupButton").addEventListener("click", () => {
   document.getElementById("boardIdPopup").style.display = "none";
 });
 
@@ -485,6 +485,25 @@ document.getElementById("boardIdForm").addEventListener("submit", (event) => {
 
     renderChatroomDiv(result);
   });
+});
+
+// 매칭 채팅방 입장 테스트 버튼 클릭 시
+document.getElementById("matchingTestButton").addEventListener("click", () => {
+  document.getElementById("matchingMemberIdPopup").style.display = "block";
+});
+
+// 매칭 채팅방 입장 팝업 닫기 버튼 클릭 시
+document.getElementById("closeMatchingMemberIdPopupButton").addEventListener("click", () => {
+  document.getElementById("matchingMemberIdPopup").style.display = "none";
+});
+
+// 매칭 채팅방 입장 팝업 제출 버튼 클릭 시
+// 매칭을 통한 채팅방 시작
+document.getElementById("mathingMemberIdForm").addEventListener("submit", (event) => {
+  event.preventDefault(); // 기본 제출 동작 방지
+  document.getElementById("matchingMemberIdPopup").style.display = "none";
+
+  const matchingMemberId = document.getElementById("mathingMemberIdInput").value;
 });
 
 // 채팅방 퇴장 시

--- a/public/scripts/socket.js
+++ b/public/scripts/socket.js
@@ -263,6 +263,40 @@ function setupSocketListeners() {
       }
     });
   });
+
+  socket.on("chat-system-message", (response) => {
+    const { chatroomUuid, ...newMessage } = response.data;
+    console.log("===================== chat-system-message EVENT LISTEN  ===================== ");
+    console.log("chatroomUuid: ", chatroomUuid, ", currentViewingChatroomUuid: ", currentViewingChatroomUuid);
+
+    // 현재 보고 있는 채팅방에서 온 시스템 메시지인 경우
+    if (chatroomUuid === currentViewingChatroomUuid) {
+      messagesFromThisChatroom.push(newMessage);
+
+      console.log("============== messagesFromThisChatroom Updated ==============");
+      console.log(messagesFromThisChatroom);
+
+      // 시스템 메시지 요소 동적 생성
+      const messagesElement = document.getElementById("messages");
+      const li = document.createElement("li");
+      li.classList.add("message-item");
+      li.classList.add("system-message");
+      if (newMessage.boardId) {
+        li.setAttribute("data-board-id", newMessage.boardId); // 특정 글로 이동해야 하는 경우, boardId 저장
+        li.addEventListener("click", function () {
+          // 클릭 시 alert 창 띄우기 (원래는 해당 boardId로 게시글 조회 API로 넘어가야 함)
+          alert(`게시판 글 조회 페이지로 이동, board id: ${newMessage.boardId}`);
+        });
+      }
+
+      li.innerHTML = `
+                    <div class="message-content" style = "cursor: pointer;">
+                        <p class="message-text">${newMessage.message}</p>
+                    </div>
+                  `;
+      messagesElement.appendChild(li);
+    }
+  });
 }
 
 // 화면 새로 로드 시 socket 다시 연결

--- a/public/scripts/socket.js
+++ b/public/scripts/socket.js
@@ -5,6 +5,7 @@ let currentChattingMemberId = null; // 현재 이 사용자가 보고 있는 채
 let currentViewingChatroomUuid = null; // 현재 이 사용자가 보고 있는 채팅방의 uuid 저장
 let messagesFromThisChatroom = []; // 현재 보고 있는 채팅방의 메시지 목록
 let hasNextChat = false; // 채팅 내역 조회를 위해, 다음 채팅내역이 존재하는지 여부 저장
+let currentSystemFlag = null; // 현재 채팅방에서 메시지 전송 시 보내야할 systemFlag 저장
 
 const loginStatus = document.getElementById("loginStatus");
 

--- a/public/styles.css
+++ b/public/styles.css
@@ -375,29 +375,6 @@ p[data-new-count] {
   margin-right: 10px;
 }
 
-/* 차단 팝업 */
-.popup {
-  position: fixed;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  background-color: white;
-  padding: 20px;
-  box-shadow: 0px 0px 10px rgba(0, 0, 0, 0.5);
-  z-index: 1000;
-  border-radius: 10px;
-}
-
-.popup-content {
-  text-align: center;
-}
-
-.popup button {
-  margin: 10px;
-  padding: 10px 20px;
-  cursor: pointer;
-}
-
 /* 시스템 메시지 */
 .system-message {
   text-align: center;
@@ -418,4 +395,83 @@ p[data-new-count] {
 
 .system-message .message-content .message-text {
   font-size: small;
+}
+
+/* 차단 팝업 */
+#blockPopup {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background-color: white;
+  padding: 20px;
+  box-shadow: 0px 0px 10px rgba(0, 0, 0, 0.5);
+  z-index: 1000;
+  border-radius: 10px;
+}
+
+#blockPopup .popup-content {
+  text-align: center;
+}
+
+#blockPopup button {
+  margin: 10px;
+  padding: 10px 20px;
+  cursor: pointer;
+}
+
+/* 게시판 말걸어보기 테스트 팝업 스타일 */
+#boardIdPopup {
+  display: none;
+  position: fixed;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  /*transform: translate(-50%, -50%); */
+  background-color: white;
+  padding: 20px;
+  border: 1px solid #ccc;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+  z-index: 1000;
+  border-radius: 10px;
+}
+
+#boardIdPopup .popup-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+#boardIdPopup .popup-content form {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+#boardIdPopup .popup-content label {
+  color: black;
+}
+
+#boardIdPopup .popup-content input {
+  padding: 5px;
+  border-radius: 5px;
+  border: 1px solid #ccc;
+}
+
+#boardIdPopup .popup-content button {
+  padding: 10px;
+  border-radius: 5px;
+  border: none;
+  cursor: pointer;
+}
+
+#boardIdPopup .popup-content button[type="submit"] {
+  background-color: #6200ea;
+  color: white;
+}
+
+#boardIdPopup .popup-content button[type="button"] {
+  background-color: #ccc;
+  color: black;
 }

--- a/public/styles.css
+++ b/public/styles.css
@@ -397,3 +397,25 @@ p[data-new-count] {
   padding: 10px 20px;
   cursor: pointer;
 }
+
+/* 시스템 메시지 */
+.system-message {
+  text-align: center;
+  padding: 10px 0;
+  background-color: #5d5d5d;
+  color: white;
+  border-radius: 10px;
+  margin: 10px 0;
+}
+
+.system-message .message-content {
+  width: 100%;
+  display: flex;
+  justify-content: center; /* 수평 가운데 정렬 */
+  align-items: center; /* 수직 가운데 정렬 */
+  height: 100%; /* 부모 요소의 높이를 채우도록 설정 */
+}
+
+.system-message .message-content .message-text {
+  font-size: small;
+}

--- a/public/styles.css
+++ b/public/styles.css
@@ -475,3 +475,59 @@ p[data-new-count] {
   background-color: #ccc;
   color: black;
 }
+
+/* 매칭 채팅방 테스트 팝업 스타일 */
+#matchingMemberIdPopup {
+  display: none;
+  position: fixed;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  /*transform: translate(-50%, -50%); */
+  background-color: white;
+  padding: 20px;
+  border: 1px solid #ccc;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+  z-index: 1000;
+  border-radius: 10px;
+}
+
+#matchingMemberIdPopup .popup-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+#matchingMemberIdPopup .popup-content form {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+#matchingMemberIdPopup .popup-content label {
+  color: black;
+}
+
+#matchingMemberIdPopup .popup-content input {
+  padding: 5px;
+  border-radius: 5px;
+  border: 1px solid #ccc;
+}
+
+#matchingMemberIdPopup .popup-content button {
+  padding: 10px;
+  border-radius: 5px;
+  border: none;
+  cursor: pointer;
+}
+
+#matchingMemberIdPopup .popup-content button[type="submit"] {
+  background-color: #6200ea;
+  color: white;
+}
+
+#matchingMemberIdPopup .popup-content button[type="button"] {
+  background-color: #ccc;
+  color: black;
+}

--- a/socket/apis/chatApi.js
+++ b/socket/apis/chatApi.js
@@ -67,7 +67,38 @@ async function postChatMessage(socket, chatroomUuid, requestData) {
   }
 }
 
+/**
+ * 매칭을 통한 채팅방 시작 테스트용 API 요청 메소드
+ * @param {*} socket
+ * @param {*} targetMemberId
+ */
+async function startTestChattingByMatching(socket, targetMemberId) {
+  try {
+    const response = await axios.get(`${API_SERVER_URL}/v1/chat/start/matching/${socket.memberId}/${targetMemberId}`, {
+      headers: {
+        Authorization: `Bearer ${socket.token}`, // Include JWT token in header
+      },
+    });
+    if (response.data.isSuccess) {
+      return response.data.result;
+    }
+  } catch (error) {
+    if (error.response && error.response.data) {
+      const data = error.response.data;
+      if (["JWT400", "JWT401", "JWT404"].includes(data.code)) {
+        console.error("JWT token Error: ", data.message);
+        throw new JWTTokenError(`JWT token Error: ${data.message}`, data.code);
+      }
+      console.error("Failed GET start matching chat test: ", data.message);
+      throw new Error(`Failed GET start matching chat test: ${data.message}`);
+    } else {
+      throw new Error(`Request failed: ${error.message}`);
+    }
+  }
+}
+
 module.exports = {
   fetchChatroomUuid,
   postChatMessage,
+  startTestChattingByMatching,
 };

--- a/socket/apis/chatApi.js
+++ b/socket/apis/chatApi.js
@@ -35,17 +35,20 @@ async function fetchChatroomUuid(socket) {
   }
 }
 
-async function postChatMessage(socket, chatroomUuid, message) {
+/**
+ * 해당 채팅방에 메시지를 등록을 요청하는 메소드
+ * @param {*} socket
+ * @param {*} chatroomUuid
+ * @param {*} requestData
+ * @returns
+ */
+async function postChatMessage(socket, chatroomUuid, requestData) {
   try {
-    const response = await axios.post(
-      `${API_SERVER_URL}/v1/chat/${chatroomUuid}`,
-      { message: message },
-      {
-        headers: {
-          Authorization: `Bearer ${socket.token}`,
-        },
-      }
-    );
+    const response = await axios.post(`${API_SERVER_URL}/v1/chat/${chatroomUuid}`, requestData, {
+      headers: {
+        Authorization: `Bearer ${socket.token}`,
+      },
+    });
     if (response.data.isSuccess) {
       return response.data.result;
     }

--- a/socket/common/memberSocketMapper.js
+++ b/socket/common/memberSocketMapper.js
@@ -1,5 +1,5 @@
 /**
- * memberId에 해당하는 현재 연결된 socket의 id를 리턴
+ * memberId list에 해당하는 현재 연결된 socket의 id list를 리턴
  * @param {Object} io
  * @param {Array<int>} memberIdList
  * @returns
@@ -16,6 +16,25 @@ async function getSocketIdsByMemberIds(io, memberIdList) {
   return socketIdList;
 }
 
+/**
+ * memberId에 해당하는 socket의 socketId 리턴
+ * @param {*} io
+ * @param {*} memberId
+ * @returns
+ */
+async function getSocketIdByMemberId(io, memberId) {
+  const connectedSockets = await io.fetchSockets();
+  console.log("requested memberId: ", memberId);
+  for (const connSocket of connectedSockets) {
+    console.log("connSocket.memberId: ", connSocket.memberId);
+    if (memberId == connSocket.memberId) {
+      return connSocket;
+    }
+  }
+  return null;
+}
+
 module.exports = {
   getSocketIdsByMemberIds,
+  getSocketIdByMemberId,
 };

--- a/socket/emitters/chatEmitter.js
+++ b/socket/emitters/chatEmitter.js
@@ -36,8 +36,19 @@ function emitJoinedNewChatroom(socket) {
   socket.emit("joined-new-chatroom", formatResponse("joined-new-chatroom", data));
 }
 
+/**
+ * 매칭을 통한 채팅방 시작 테스트 성공되었음을 chatroom에 있는 모든 socket 에게 전달
+ * @param {*} io
+ * @param {*} chatroomUuid
+ */
+function emitTestMatchingChattingSuccess(io, chatroomUuid) {
+  const data = { chatroomUuid: chatroomUuid };
+  io.to("CHAT_" + chatroomUuid).emit("test-matching-chatting-success", formatResponse("test-matching-chatting-success", data));
+}
+
 module.exports = {
   emitChatMessage,
   emitJoinedNewChatroom,
   emitChatSystemMessage,
+  emitTestMatchingChattingSuccess,
 };

--- a/socket/emitters/chatEmitter.js
+++ b/socket/emitters/chatEmitter.js
@@ -17,6 +17,17 @@ function emitChatMessage(socket, chatroomUuid, data) {
 }
 
 /**
+ * system message를 chatroomUuid room에 있는 상대 socket에게 전달
+ * @param {*} socket
+ * @param {*} chatroomUuid
+ * @param {*} targetSystemMessage
+ */
+function emitChatSystemMessage(socket, chatroomUuid, targetSystemMessage) {
+  // uuid에 해당하는 room에 있는 socket 중 나를 제외한 socket에 broadcast
+  socket.broadcast.to("CHAT_" + chatroomUuid).emit("chat-system-message", formatResponse("chat-system-message", targetSystemMessage));
+}
+
+/**
  * 해당 socket이 새로운 chatroom에 join되었음을 전달
  * @param {*} socket
  */
@@ -28,4 +39,5 @@ function emitJoinedNewChatroom(socket) {
 module.exports = {
   emitChatMessage,
   emitJoinedNewChatroom,
+  emitChatSystemMessage,
 };

--- a/socket/handlers/chat/chatHandler.js
+++ b/socket/handlers/chat/chatHandler.js
@@ -18,8 +18,15 @@ function setupChatListeners(socket) {
       emitError(socket, "Fail listening chat-message event: chatroomUuid is missing");
     }
 
+    let requestData = { message: msg };
+
+    // 시스템 값 담아 보내야 하는 경우
+    if (request.system) {
+      requestData.system = request.system;
+    }
+
     // (#10-2) 8080서버에 채팅 저장 api 요청
-    postChatMessage(socket, chatroomUuid, msg)
+    postChatMessage(socket, chatroomUuid, requestData)
       .then((response) => {
         // (#10-8) 채팅 저장 정상 응답 받음
         // (#10-9),(#10-10) 해당 채팅방의 상대 회원에게 chat-message emit, 내 socket에게 my-message-broadcast-success emit

--- a/socket/handlers/chat/chatHandler.js
+++ b/socket/handlers/chat/chatHandler.js
@@ -2,7 +2,7 @@ const JWTTokenError = require("../../../common/JWTTokenError");
 
 const { emitError, emitJWTError } = require("../../emitters/errorEmitter");
 const { postChatMessage } = require("../../apis/chatApi");
-const { emitChatMessage } = require("../../emitters/chatEmitter");
+const { emitChatMessage, emitChatSystemMessage } = require("../../emitters/chatEmitter");
 /**
  * socket event에 대한 listener
  * @param {*} socket
@@ -20,9 +20,23 @@ function setupChatListeners(socket) {
 
     let requestData = { message: msg };
 
-    // 시스템 값 담아 보내야 하는 경우
+    // 시스템 값이 있는 경우
     if (request.system) {
       requestData.system = request.system;
+
+      // 상대방 socket에게 시스템 메시지 먼저 emit
+      // chat-system-message emit
+      const targetSystemMessage = {
+        chatroomUuid: chatroomUuid,
+        senderId: 0,
+        senderName: "SYSTEM",
+        senderProfileImg: 0,
+        message: "내가 게시한 글을 보고 말을 걸어왔어요.",
+        createdAt: null,
+        timestamp: null,
+        boardId: request.system.boardId,
+      };
+      emitChatSystemMessage(socket, chatroomUuid, targetSystemMessage);
     }
 
     // (#10-2) 8080서버에 채팅 저장 api 요청


### PR DESCRIPTION
## 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요. -->

## 🔍 변경사항
<!-- 이 PR로 인해 바뀌게 되는 것들을 목록으로 적어주세요. -->
- 채팅방 시작 API endpoint 변경 반영
- 채팅방 시작 API 응답에 system 값 관련 로직 추가
- 게시글 말 걸어보기 테스트 기능 추가
- 매칭을 통한 채팅방 시작 테스트 기능 추가

## ⏳ 작업 내용
- [x]  채팅방 시작 API endpoint 변경 반영
- [x]  채팅방 시작 API 응답에 system 값 관련 로직 추가
    - [x]  system 값 있으면 채팅 메시지 첫 전송 시 chat-message emit에 같이 보내기
    - [x] chat-message listener에서 채팅 등록 API 요청 시 system 값 포함해 보내기
- [x]  메시지 내역 조회 결과에 시스템 메시지 렌더링 코드 추가
- [x]  “게시글 말걸어보기 테스트” 버튼
    - [x]  버튼 html 생성, 버튼 클릭 시 게시글 postId를 보낼 수 있는 form 팝업 띄우기
    - [x]  말걸어보기 버튼 클릭 시, 특정 글을 통한 채팅방 시작 api 연동
    - [x]  말걸어보기 버튼 클릭 시, 띄웠던 팝업 닫고 api 응답에 따라 채팅방 목록 + 채팅방 내부 화면 렌더링
- [x]  “매칭 성공 채팅방 연결 테스트” 버튼
    - [x]  버튼 html 생성, 버튼 클릭 시 상대 memberId를 보낼 수 있는 form 팝업 띄우기
    - [x]  매칭 성공 연결 테스트 버튼 클릭 시, test-matching-request event emit
    - [x] 3000서버에 test-matching-request event listener 구현: 매칭을 통한 채팅방 시작 테스트용 api 호출 및 socket room join, test-matching-chatting-success event emit
    - [x]  클라이언트 test-matching-chatting-success event listener 구현: 채팅방 입장 api 호출 및 화면 렌더링, 채팅방 목록 조회 api 요청 및 화면 렌더링

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
