### PR TITLE
[Feat/63] matching_not_found 로직 추가

### DIFF
--- a/public/matching/scripts/socket.js
+++ b/public/matching/scripts/socket.js
@@ -34,10 +34,23 @@ function setUpMatchingSocketListeners() {
     const timeoutId = setTimeout(() => {
       // 2분 동안 "matching-found-sender" or "matching-found-receiver" 이벤트가 발생하지 않으면 매칭 재시작 요청
       socket.emit("matching-retry", { priority: 50 });
+
+      // 3분 타이머 시작, matching_not_found 
+      const timeoutIdforNotFound = setTimeout(()=>{        
+        // matching_retry 이후 "matching-found-sender" or "matching-found-receiver" 이벤트가 발생하지 않을 경우 matching-not-found emit 전송
+        socket.emit("matching-not-found");
+
+        alert("매칭을 찾을 수 없습니다.");
+
+        window.location.href = "/";
+
+      },180000); // 180000ms = 3분
     }, 120000); // 120000ms = 2분
 
     timers.matchingRetryCallback = timeoutId;
+    timers.matchingNotFoundCallback = timeoutIdforNotFound;
     console.log(timers);
+
   });
 
   // "matching-found-receiver" event listener : receiver socket
@@ -45,6 +58,10 @@ function setUpMatchingSocketListeners() {
     // 매칭 상대가 정해졌으므로, matchingRetry callback 취소
     clearTimeout(timers.matchingRetryCallback);
     delete timers.matchingRetryCallback;
+    
+    // 매칭 상대가 정해졌으므로, matchingNotFound callback 취소
+    clearTimeout(timers.matchingNotFoundCallback);
+    delete timers.matchingNotFoundCallback;
 
     // 13) matching-found-success emit
     socket.emit("matching-found-success", { senderMemberId: response.data.memberId, gameMode: response.data.gameMode });
@@ -81,6 +98,10 @@ function setUpMatchingSocketListeners() {
     // 매칭 상대가 정해졌으므로, matchingRetry callback 취소
     clearTimeout(timers.matchingRetryCallback);
     delete timers.matchingRetryCallback;
+
+    // 매칭 상대가 정해졌으므로, matchingNotFound callback 취소
+    clearTimeout(timers.matchingNotFoundCallback);
+    delete timers.matchingNotFoundCallback;
 
     // 10초 타이머 시작, matchingSuccessSender call back
     setTimeout(() => {

--- a/socket/handlers/matching/matchingHandler/matchingFoundHandler.js
+++ b/socket/handlers/matching/matchingHandler/matchingFoundHandler.js
@@ -37,4 +37,37 @@ function deleteSocketFromMatching(socket, io, otherSocket, roomName) {
   otherSocket.highestPriorityNode = null;
 }
 
-module.exports = { deleteSocketFromMatching };
+/**
+ * 소켓 자신만을 매칭 풀에서 삭제 (room leave, priorityTree 제거 및 초기화)
+ * @param {*} socket
+ * @param {*} otherSocket
+ * @param {*} roomName
+ */
+function deleteMySocketFromMatching(socket, io, roomName) {
+  // 14) 소켓 룸에서 제거
+  socket.leave(roomName);
+
+  // 15) priorityTree에서 삭제
+  const room = io.sockets.adapter.rooms.get(roomName);
+
+  if (room) {
+    // 룸에 있는 각 소켓에 대해 콜백 함수 실행
+    room.forEach((socketId) => {
+      const roomSocket = io.sockets.sockets.get(socketId);
+      if (roomSocket) {
+        // roomSocket의 priorityTree에서 socket의 값을 지우기
+        roomSocket.priorityTree.removeByMemberId(socket.memberId);
+      }
+    });
+  } else {
+    console.log(`Room ${roomName} does not exist or is empty.`);
+  }
+
+  // 16) 각자의 priorityTree 삭제
+  socket.priorityTree.clear();
+
+  // 각자의 highestPriorityNode 삭제
+  socket.highestPriorityNode = null;
+}
+
+module.exports = { deleteSocketFromMatching, deleteMySocketFromMatching };


### PR DESCRIPTION
## 🚀 개요
매칭 시작 후 5분이 지날 경우 matching_not_found 로직 추가

## 🔍 변경사항
- 매칭 후 5분이 지날 경우 matching-not-found emit 발생
- 3000번 서버에서 matching-not-found, matching-retry 리스너 생성 (matching-retry 리스너는 다른 이슈에서 해결할 예정)

## ⏳ 작업 내용
- [x] deleteMySocketFromMatching(socket, io, roomName) 추가
- [x] matching 풀에서 소켓 제거
- [x] 5분 지나서 매칭 실패일 경우 alert 및 / 화면으로 전환

### 📝 논의사항
