### PR TITLE
[Feat/67] 매칭 실패 로직

### DIFF
--- a/public/matching/scripts/socket.js
+++ b/public/matching/scripts/socket.js
@@ -229,6 +229,14 @@ function startRetryCountdown() {
   // 버튼을 보여줌
   retryButton.style.display = "inline-block"; // or 'block', depending on your layout
 
+  console.log(retryButton);
+  // 클릭되면 matching-fail emit
+  retryButton.addEventListener("click", ()=> {
+    console.log("MATCHING_FAILED");
+    socket.emit("matching-fail");
+    window.location.href("/");
+  });
+
   let countdown = 10; // 카운트다운 시작 값
 
   // 카운트다운 함수

--- a/public/matching/scripts/socket.js
+++ b/public/matching/scripts/socket.js
@@ -1,7 +1,6 @@
 let elapsedSeconds = 0; // 타이머 경과된 시간 (초)
 let searchingTimerInterval; // 매칭중 타이머
 let timers = {};
-
 let isMatchingSuccessSenderArrived = false; // matching-success-sender가 도착했는지 여부를 추적
 
 // 포지션 값을 텍스트로 변환하는 함수
@@ -153,6 +152,9 @@ function setUpMatchingSocketListeners() {
     // 최종 매칭 결과가 도착했으므로, matchingFail callback clear
     clearTimeout(timers.matchingFailCallback);
     delete timers.matchingFailCallback;
+
+    window.location.href = "/";
+
   });
 }
 
@@ -229,12 +231,13 @@ function startRetryCountdown() {
   // 버튼을 보여줌
   retryButton.style.display = "inline-block"; // or 'block', depending on your layout
 
-  console.log(retryButton);
+
   // 클릭되면 matching-fail emit
-  retryButton.addEventListener("click", ()=> {
+  retryButton.addEventListener("click", () => {
     console.log("MATCHING_FAILED");
     socket.emit("matching-fail");
-    window.location.href("/");
+    window.location.href = "/";
+
   });
 
   let countdown = 10; // 카운트다운 시작 값

--- a/socket/emitters/matchingEmitter.js
+++ b/socket/emitters/matchingEmitter.js
@@ -44,10 +44,16 @@ function emitMatchingSuccess(senderSocket, receiverSocket, chatroomUuid) {
   receiverSocket.emit("matching-success", formatResponse("matching-success", { chatroomUuid: chatroomUuid }));
 }
 
+function emitMatchingFail(socket){
+  socket.emit("matching-fail",formatResponse("matching-fail","매칭이 실패했습니다."));
+}
+
+
 module.exports = {
   emitMatchingStarted,
   emitMatchingFoundReceiver,
   emitMatchingFoundSender,
   emitMatchingSuccessSender,
   emitMatchingSuccess,
+  emitMatchingFail
 };

--- a/socket/handlers/matching/matchingSocketListeners.js
+++ b/socket/handlers/matching/matchingSocketListeners.js
@@ -150,7 +150,9 @@ async function setupMatchSocketListeners(socket, io) {
     socket.matchingTarget=null;
 
     // 29) otherSocket.matchingTarget 제거
-    otherSocket.matchingTarget=null;
+    if(otherSocket){
+      otherSocket.matchingTarget=null;
+    }
   });
 
   socket.on("matching-retry", async (request) => {

--- a/socket/handlers/matching/matchingSocketListeners.js
+++ b/socket/handlers/matching/matchingSocketListeners.js
@@ -137,7 +137,14 @@ async function setupMatchSocketListeners(socket, io) {
 
   socket.on("matching-fail", (request) => {
     console.log("================= matching_fail ======================");
-    console.log("member ID:", socket.memberId);
+    console.log("socket : ", socket);
+
+    // 26) 매칭 FAIL API 요청
+
+    // 27) 상대 client에게 matching-fail emit
+
+    // 28) socket.target 제거
+    
   });
 
   socket.on("matching-retry", async (request) => {
@@ -169,12 +176,12 @@ async function setupMatchSocketListeners(socket, io) {
     deleteMySocketFromMatching(socket, io, roomName);
 
     // 17) matching_status 변경
-    try{
+    try {
       const result = await updateMatchingStatusApi(socket, "FAIL");
-      if(result){
+      if (result) {
         console.log("Matching Not Found 처리 완료");
       }
-    }catch (error) {
+    } catch (error) {
       handlerSocketError(socket, error);
     }
   })


### PR DESCRIPTION
## 🚀 개요
매칭 실패 로직 구현했습니다

## 🔍 변경사항
- 매칭 다시하기 버튼 누르면 매칭 실패 로직 

## ⏳ 작업 내용
- [x] client 측 socket emit, socket on 
- [x] 3000번 로직 구현

### 📝 논의사항
* 매칭 실패 시 3000번 로직
    26) 매칭 FAIL API 요청
    27) 상대 client에게 matching-fail emit
    28) socket.target 제거
    29) otherSocket.matchingTarget 제거