### PR TITLE
[Fix/71] 친구 목록 조회 API 변경에 따른 소켓 초기화 로직 수정

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -234,7 +234,7 @@ app.get("/", (req, res) => {
           </div>
         </div>
           <div class="content">
-            <div class="column">
+            <div class="column friends">
               <h2>
                 친구 목록
                 <button id="fetchFriendsButton"> ↻ </button>

--- a/public/scripts/api.js
+++ b/public/scripts/api.js
@@ -60,10 +60,14 @@ async function loginNodeApi() {
   }
 }
 
-async function getFriendListApi() {
+async function getFriendListApi(cursor) {
   try {
     const jwtToken = localStorage.getItem("jwtToken");
-    const response = await fetch(`${API_SERVER_URL}/v1/friends`, {
+    let url = `${API_SERVER_URL}/v1/friends`;
+    if (cursor) {
+      url += `?cursor=${cursor}`;
+    }
+    const response = await fetch(url, {
       headers: {
         Authorization: `Bearer ${jwtToken}`, // Include JWT token in header
       },

--- a/public/scripts/eventListeners.js
+++ b/public/scripts/eventListeners.js
@@ -41,14 +41,17 @@ fetchFriendsButton.addEventListener("click", () => {
   }
 
   // (#3-1) 친구 목록 조회 api 요청
-  getFriendListApi().then((result) => {
+  getFriendListApi(null).then((result) => {
     if (result) {
       // (#3-2) 친구 목록 조회 성공 응답 받음
       const friendsElement = document.getElementById("friendsList");
       friendsElement.innerHTML = ""; // 이전 친구목록 element 비우기
 
+      hasNextFriend = result.has_next;
+      nextFriendCursor = result.next_cursor;
+
       // (#3-3) 친구 목록 화면 렌더링
-      result.forEach((friend) => {
+      result.friendInfoDTOList.forEach((friend) => {
         const li = document.createElement("li");
 
         // onlineFriendMemberIdList에 존재하는 회원인지 (해당 회원이 현재 온라인인지)에 따라 상태 text 배정
@@ -136,6 +139,131 @@ fetchFriendsButton.addEventListener("click", () => {
     }
   });
 });
+
+// 친구 목록 내부에서 스크롤이 가장 아래에 닿았을 때
+document.addEventListener("DOMContentLoaded", () => {
+  const friendsListElement = document.getElementById("friendsList");
+
+  friendsListElement.addEventListener("scroll", () => {
+    // 스크롤이 가장 아래에 닿았는지 확인
+    const isScrollAtBottom = friendsListElement.scrollTop + friendsListElement.clientHeight >= friendsListElement.scrollHeight;
+
+    if (isScrollAtBottom) {
+      // 더 조회해올 다음 친구 목록이 있다면
+      if (hasNextFriend) {
+        fetchNextFriends(nextFriendCursor);
+      } else {
+        console.log("=== End of Friend List, No fetch ===");
+      }
+    }
+  });
+});
+
+// nextFriendCursor 기반으로 다음 친구 목록 조회 api 요청 및 화면 렌더링
+function fetchNextFriends(cursor) {
+  const jwtToken = localStorage.getItem("jwtToken");
+  if (!jwtToken) {
+    console.error("JWT token is missing.");
+    return;
+  }
+
+  getFriendListApi(cursor).then((result) => {
+    if (result) {
+      // (#3-2) 친구 목록 조회 성공 응답 받음
+      const friendsElement = document.getElementById("friendsList");
+
+      hasNextFriend = result.has_next;
+      nextFriendCursor = result.next_cursor;
+
+      // (#3-3) 친구 목록 화면 렌더링
+      result.friendInfoDTOList.forEach((friend) => {
+        const li = document.createElement("li");
+
+        // onlineFriendMemberIdList에 존재하는 회원인지 (해당 회원이 현재 온라인인지)에 따라 상태 text 배정
+        const isOnline = onlineFriendMemberIdList.includes(friend.memberId);
+        const statusText = isOnline ? "online" : "offline";
+
+        // 접속 상태 element 생성 및 class 부여
+        const statusElement = document.createElement("span");
+        statusElement.textContent = `(${statusText})`;
+        statusElement.classList.add(isOnline ? "online" : "offline");
+
+        li.setAttribute("data-member-id", friend.memberId);
+
+        // 사용자 정보를 담는 div 생성
+        const userInfoDiv = document.createElement("div");
+        userInfoDiv.className = "user-info"; // CSS 클래스 추가
+        userInfoDiv.innerHTML = `
+                <img src="${friend.memberProfileImg}" alt="${friend.name}'s profile picture" width="30" height="30">
+                <span>${friend.name}</span>
+            `;
+        li.appendChild(userInfoDiv);
+        li.appendChild(statusElement);
+
+        // 즐겨찾기 여부 표시
+        // 별 아이콘 추가
+        const star = document.createElement("span");
+        star.className = "star";
+        star.innerHTML = "☆";
+
+        // liked가 true인 경우 보라색으로 설정
+        if (friend.liked) {
+          star.classList.add("liked");
+        }
+
+        // li 요소에 별 아이콘 추가
+        li.appendChild(star);
+
+        // 해당 친구 부분 클릭 시, 친구와의 채팅방 시작 api 요청
+        userInfoDiv.addEventListener("click", () => {
+          // (#13-1) 채팅방 시작 API 요청
+          startChatByMemberIdApi(friend.memberId).then((result) => {
+            // (#13-2) 채팅방 시작 API 정상 응답 받음
+            // (#13-3) messagesFromThisChatroom array 초기화
+            messagesFromThisChatroom = result.chatMessageList.chatMessageDtoList;
+
+            console.log("============== fetch chat messages result ===============");
+            console.log(result.chatMessageList.chatMessageDtoList);
+
+            // (#13-4) hasNextChat 업데이트
+            hasNextChat = result.chatMessageList.has_next;
+
+            // (#13-5) 현재 보고 있는 채팅방 uuid, 채팅 중인 memberId 업데이트
+            currentViewingChatroomUuid = result.uuid;
+            currentChattingMemberId = result.memberId;
+
+            // (#13-6) systemFlag 초기화, 특정 회원과의 채팅방 시작 시 systemFlag는 항상 null임
+            currentSystemFlag = null;
+
+            renderChatroomDiv(result);
+          });
+        });
+
+        // 별 아이콘 클릭 시, 해당 친구 즐겨찾기 설정/해제 요청 전송
+        star.addEventListener("click", () => {
+          // liked 클래스가 있는지 확인
+          if (star.classList.contains("liked")) {
+            // 즐겨찾기 해제 api 요청
+            unstarFriendApi(friend.memberId).then((result) => {
+              // liked 상태 변경
+              star.classList.remove("liked");
+              console.log("즐겨찾기 해제 성공, memberId: ", friend.memberId);
+            });
+          } else {
+            // 즐겨찾기 설정 api 요청
+            starFriendApi(friend.memberId).then((result) => {
+              // liked 상태 변경
+              star.classList.add("liked");
+              console.log("즐겨찾기 설정 성공, memberId: ", friend.memberId);
+            });
+          }
+        });
+
+        friendsElement.appendChild(li);
+      });
+    }
+  });
+}
 
 // 로그아웃 버튼 클릭 시
 logoutButton.addEventListener("click", () => {

--- a/public/scripts/eventListeners.js
+++ b/public/scripts/eventListeners.js
@@ -94,14 +94,24 @@ fetchFriendsButton.addEventListener("click", () => {
           // (#13-1) 채팅방 시작 API 요청
           startChatByMemberIdApi(friend.memberId).then((result) => {
             // (#13-2) 채팅방 시작 API 정상 응답 받음
-            // (#13-3) messagesFromThisChatroom array 초기화
-            messagesFromThisChatroom = result.chatMessageList.chatMessageDtoList;
+            if (result.chatMessageList) {
+              // 채팅 메시지 내역이 있을 때에만
+              // (#13-3) messagesFromThisChatroom array 초기화
+              messagesFromThisChatroom = result.chatMessageList.chatMessageDtoList;
 
-            console.log("============== fetch chat messages result ===============");
-            console.log(result.chatMessageList.chatMessageDtoList);
+              console.log("============== fetch chat messages result ===============");
+              console.log(result.chatMessageList.chatMessageDtoList);
 
-            // (#13-4) hasNextChat 업데이트
-            hasNextChat = result.chatMessageList.has_next;
+              // (#13-4) hasNextChat 업데이트
+              hasNextChat = result.chatMessageList.has_next;
+            } else {
+              // 채팅 메시지 내역이 아예 없을 경우
+              // messagesFromThisChatroom array 초기화
+              messagesFromThisChatroom = [];
+
+              // hasNext null로 초기화
+              hasNextChat = null;
+            }
 
             // (#13-5) 현재 보고 있는 채팅방 uuid, 채팅 중인 memberId 업데이트
             currentViewingChatroomUuid = result.uuid;

--- a/public/scripts/socket.js
+++ b/public/scripts/socket.js
@@ -5,6 +5,8 @@ let currentChattingMemberId = null; // 현재 이 사용자가 보고 있는 채
 let currentViewingChatroomUuid = null; // 현재 이 사용자가 보고 있는 채팅방의 uuid 저장
 let messagesFromThisChatroom = []; // 현재 보고 있는 채팅방의 메시지 목록
 let hasNextChat = false; // 채팅 내역 조회를 위해, 다음 채팅내역이 존재하는지 여부 저장
+let hasNextFriend = false; // 친구 목록 조회를 위해, 다음 친구 목록이 존재하는지 여부 저장
+let nextFriendCursor = null; // 다음 친구 목록 조회를 위한 커서
 let currentSystemFlag = null; // 현재 채팅방에서 메시지 전송 시 보내야할 systemFlag 저장
 
 const loginStatus = document.getElementById("loginStatus");

--- a/public/styles.css
+++ b/public/styles.css
@@ -51,6 +51,14 @@ html {
   background-color: #e9e9e9;
 }
 
+.friends {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  box-sizing: border-box;
+  overflow: hidden; /* Prevent scrolling in the chatroom area */
+}
+
 .chatroom {
   display: flex;
   flex-direction: column;
@@ -151,12 +159,15 @@ p[data-new-count] {
 #friendsList {
   list-style-type: none; /* Remove default bullet points */
   padding: 5px; /* Remove default padding */
+  flex: 1;
+  overflow-y: auto; /* Enable scrolling in the messages area */
+  padding-left: 5px;
 }
 
 #friendsList li {
   display: flex; /* Use flexbox for alignment */
   align-items: center; /* Center items vertically */
-  padding: 10px 0; /* Add vertical padding for spacing */
+  padding: 20px 0; /* Add vertical padding for spacing */
   border-bottom: 1px solid #ccc; /* Add a bottom border */
 }
 
@@ -531,12 +542,14 @@ label {
   display: block;
   margin-bottom: 10px;
   margin-left: 10px;
-  color: #5C5C5C;
+  color: #5c5c5c;
 }
-input[type="text"], input[type="number"], select {
+input[type="text"],
+input[type="number"],
+select {
   width: 100%;
   padding: 10px;
-  border: 1px solid #D9D9D9;
+  border: 1px solid #d9d9d9;
   border-radius: 3px;
   box-sizing: border-box;
   margin-bottom: 20px;
@@ -552,4 +565,3 @@ input[type="text"], input[type="number"], select {
   margin: 5px;
   width: 48%;
 }
-

--- a/socket/apis/friendApi.js
+++ b/socket/apis/friendApi.js
@@ -11,7 +11,7 @@ const API_SERVER_URL = config.apiServerUrl;
  */
 async function fetchFriends(socket) {
   try {
-    const response = await axios.get(`${API_SERVER_URL}/v1/friends`, {
+    const response = await axios.get(`${API_SERVER_URL}/v1/friends/ids`, {
       headers: {
         Authorization: `Bearer ${socket.token}`, // Include JWT token in header
       },

--- a/socket/handlers/friend/friendInitializer.js
+++ b/socket/handlers/friend/friendInitializer.js
@@ -14,10 +14,7 @@ function initializeFriend(socket, io) {
   // (#1-13),(#2-9) 해당 회원의 친구 목록 조회 api 요청
   // (#1-14),(#2-10) 친구 목록 조회 정상 응답 받음
   fetchFriends(socket)
-    .then(async (friends) => {
-      // 친구 중에서 현재 온라인인 친구의 소켓 id 및 memberId array 생성
-      const friendIdList = friends.map((friend) => friend.memberId);
-
+    .then(async (friendIdList) => {
       // 친구 memberId로 socketId 찾기
       const friendSocketList = await getSocketIdsByMemberIds(io, friendIdList);
 

--- a/socket/socket.js
+++ b/socket/socket.js
@@ -70,10 +70,7 @@ function initializeSocket(server) {
         // (#6-2) 친구 목록 조회 api 요청
         // (#6-3) 친구 목록 조회 성공 응답 받음
         fetchFriends(socket)
-          .then(async (friends) => {
-            // 친구 중에서 현재 온라인인 친구의 소켓 id 및 memberId array 생성
-            const friendIdList = friends.map((friend) => friend.memberId);
-
+          .then(async (friendIdList) => {
             // (#6-4) 친구 memberId로 socketId 찾기
             const friendSocketList = await getSocketIdsByMemberIds(io, friendIdList);
 


### PR DESCRIPTION
## 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요. -->
친구 목록 조회 API 변경에 따른 소켓 초기화 로직 수정

## 🔍 변경사항
<!-- 이 PR로 인해 바뀌게 되는 것들을 목록으로 적어주세요. -->
- 3000서버 -> 8000서버로 친구 목록 조회 API 요청했던 부분을 친구 id 목록 조회 API 요청하도록 변경
- 친구 목록 화면에 스크롤바 추가 및 스크롤이 가장 아래에 닿았을 때 다음 친구 목록 조회하도록 추가
- 친구 목록을 통해 채팅방 입장한 경우 + 해당 채팅방에 아무 메시지 내역이 없는 경우에 채팅방 내부 화면 렌더링 안되던 버그 수정

## ⏳ 작업 내용
- [x] 친구 목록 렌더링 및 친구 목록 조회 API 관련 스크립트, css, html 추가
- [x] 3000서버의 친구 목록 조회 API 호출 부분 변경

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
