### PR TITLE
[Feat/127] 매칭 내 사용자 수 실시간으로 나타내기

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -88,6 +88,12 @@ app.get("/match", (req, res) => {
                     <div class="timer">
                       <p><span id="timer-value" style="color: #6200ea;">0:00</span> / 5:00</p>
                     </div>
+                    <div class="matching-info">
+                      <p id="totalUserCount">현재 게임 모드에서 대기 중인 유저 수: 0명</p>
+                      <p id="TierUserCount"> 내 티어의 대기 중인 유저 수 : 0명</p>
+                      <ul id="tierUserCounts"></ul>
+                    </div>
+
                   </div>
                   <div class="match-content">
                     <div class="left-side">

--- a/public/scripts/matching/matchingEventListeners.js
+++ b/public/scripts/matching/matchingEventListeners.js
@@ -5,7 +5,6 @@ matchButton.addEventListener("click", () => {
   
   const matchingType = document.getElementById("matching-type").value;
   const gameMode = document.getElementById("game-mode").value;
-  console.log(gameMode);
   const mike = document.getElementById("mike").value;
   const mainP = document.getElementById("mainP").value;
   const subP = document.getElementById("subP").value;

--- a/public/scripts/matching/matchingSocketEventHandlers.js
+++ b/public/scripts/matching/matchingSocketEventHandlers.js
@@ -94,10 +94,6 @@ export function handleMatchingFoundReceiver(socket, state, request) {
     clearTimeout(timers.matchingNotFoundCallback); // 5분 후 강제 종료 타이머 중지
     delete timers.matchingRetryInterval;
     delete timers.matchingNotFoundCallback;
-
-    // 매칭 상대가 정해졌으므로, matchingRetry callback 취소
-    clearTimeout(timers.matchingRetryCallback);
-    delete timers.matchingRetryCallback;
     
     // state에 저장
     state.matchingUuid = request.data.receiverMatchingUuid;
@@ -133,6 +129,10 @@ export function handleMatchingFoundReceiver(socket, state, request) {
     // 클릭되면 matching-fail emit
     quitButton.addEventListener("click", () => {
         console.log("MATCHING_QUIT");
+        clearInterval(timers.matchingRetryInterval); // 매칭 재시도 타이머 중지
+        clearTimeout(timers.matchingNotFoundCallback); // 5분 후 강제 종료 타이머 중지
+        delete timers.matchingRetryInterval;
+        delete timers.matchingNotFoundCallback;
         socket.emit("matching-quit");
     });
 
@@ -149,10 +149,8 @@ export function handleMatchingFoundReceiver(socket, state, request) {
 export function handleMatchingFoundSender(socket, state, request) {
     console.log("✅ MATCHING FOUND!");
 
-    // 매칭 상대가 정해졌으므로, matchingRetry callback 취소
-    clearTimeout(timers.matchingRetryCallback);
-    delete timers.matchingRetryCallback;
-    clearInterval(timers.matchingRetryInterval); // 매칭 재시도 타이머 중지
+    // 매칭 재시도 타이머 중지
+    clearInterval(timers.matchingRetryInterval); 
     delete timers.matchingRetryInterval;
 
     // 매칭 상대가 정해졌으므로, matchingNotFound callback 취소
@@ -192,6 +190,7 @@ export function handleMatchingFoundSender(socket, state, request) {
     // 클릭되면 matching-fail emit
     quitButton.addEventListener("click", () => {
         console.log("MATCHING_QUIT");
+        
         socket.emit("matching-quit");
 
     });

--- a/public/scripts/matching/matchingSocketEventHandlers.js
+++ b/public/scripts/matching/matchingSocketEventHandlers.js
@@ -13,6 +13,7 @@ export function handleMatchingStarted(socket, state, request) {
     console.log("MATCHING_STARTED");
 
     state.matchingUuid=request.data.matchingUuid;
+    state.tier=request.data.tier;
     console.log("memberId : ", state.memberId, "matchingUuid: ", state.matchingUuid);
 
     // 매칭중 화면 렌더링
@@ -236,6 +237,32 @@ export function handleMatchingFail(socket, request) {
     console.log("❌ MATCHING FAIL");
     socket.emit("matching-fail");
 
+}
+
+/**
+ * "matching-count"
+ * @param {*} socket 
+ * @param {*} request 
+ */
+export function handleMatchingCount(state, request) {
+    const data = request.data;
+    const userCount = data.userCount;
+    const tierCount = data.tierCount;
+    const myTier = state.tier;
+
+    // 총 유저 수 표시
+    const totalUserCountElement = document.getElementById("totalUserCount");
+    if (totalUserCountElement) {
+      totalUserCountElement.textContent = `현재 게임 모드에서 대기 중인 유저 수: ${userCount}명`;
+    }
+    // 내 티어에 해당하는 사용자 수 표시
+    console.log(tierCount);
+    const myTierCount = tierCount[myTier] ?? 0;
+    console.log(myTierCount);
+    const myTierUserCountElement = document.getElementById("TierUserCount");
+    if (myTierUserCountElement) {
+      myTierUserCountElement.textContent = `내 티어의 대기 중인 유저 수: ${myTierCount}명`;
+    }
 }
 
 // 타이머 업데이트

--- a/public/scripts/matching/matchingSocketEventHandlers.js
+++ b/public/scripts/matching/matchingSocketEventHandlers.js
@@ -152,6 +152,8 @@ export function handleMatchingFoundSender(socket, state, request) {
     // 매칭 상대가 정해졌으므로, matchingRetry callback 취소
     clearTimeout(timers.matchingRetryCallback);
     delete timers.matchingRetryCallback;
+    clearInterval(timers.matchingRetryInterval); // 매칭 재시도 타이머 중지
+    delete timers.matchingRetryInterval;
 
     // 매칭 상대가 정해졌으므로, matchingNotFound callback 취소
     clearTimeout(timers.matchingNotFoundCallback);

--- a/public/scripts/socket.js
+++ b/public/scripts/socket.js
@@ -6,6 +6,7 @@ export let socket;
 export const state = {
   socketId: null,
   memberId: null, // 이 사용자의 memberId
+  tier: null, // 이 사용자의 tier
   matchingUuid: null,
   onlineFriendMemberIdList: [], // 현재 온라인인 친구의 memberId
   currentChattingMemberId: null, // 현재 이 사용자가 보고 있는 채팅방의 상대 memberId

--- a/public/scripts/socketListeners.js
+++ b/public/scripts/socketListeners.js
@@ -19,7 +19,8 @@ import {
   handleMatchingFoundSender,
   handleMatchingSuccessSender,
   handleMatchingSuccess,
-  handleMatchingFail
+  handleMatchingFail,
+  handleMatchingCount
 } from "./matching/matchingSocketEventHandlers.js"
 
 /**
@@ -64,4 +65,6 @@ export function setupSocketListeners(socket, state) {
   socket.on("matching-success",(data)=>handleMatchingSuccess(data));
 
   socket.on("matching-fail",(data)=>handleMatchingFail(socket,data));
+
+  socket.on("matching-count",(data)=>handleMatchingCount(state,data));
 }

--- a/socket/common/memberSocketMapper.js
+++ b/socket/common/memberSocketMapper.js
@@ -55,7 +55,7 @@ async function getSocketIdByMatchingUuid(io, matchingUuid) {
     const connectedSockets = await io.fetchSockets();
 
     for (const connSocket of connectedSockets) {
-      if (matchingUuid == connSocket.data.matching.matchingUuid) {
+      if (matchingUuid == connSocket.data?.matching?.matchingUuid) {
         return connSocket;
       }
     }

--- a/socket/emitters/matchingEmitter.js
+++ b/socket/emitters/matchingEmitter.js
@@ -61,6 +61,22 @@ function emitMatchingFail(socket) {
   log.emit("matching-fail", socket, `my matching info: ${JSON.stringify(myMatchingInfo)}`);
 }
 
+/**
+ * 매칭 룸 인원 수 및 티어별 인원수 브로드캐스트
+ * @param {*} io 
+ * @param {string} roomName 
+ * @param {number} totalCount 
+ * @param {object} userCountByTier 
+ */
+function emitMatchingRoomStatus(io, roomName, totalCount, userCountByTier) {
+
+  io.to(roomName).emit("matching-count", formatResponse("matching-count", {
+    userCount: totalCount,
+    tierCount: userCountByTier,
+  }));
+
+  log.emit("matching-count", roomName, `userCount: ${totalCount}, tierCount: ${JSON.stringify(userCountByTier)}`);
+}
 module.exports = {
   emitMatchingStarted,
   emitMatchingFoundReceiver,
@@ -68,4 +84,5 @@ module.exports = {
   emitMatchingSuccessSender,
   emitMatchingSuccess,
   emitMatchingFail,
+  emitMatchingRoomStatus
 };

--- a/socket/handlers/matching/matchingHandler/matchingFailHandler.js
+++ b/socket/handlers/matching/matchingHandler/matchingFailHandler.js
@@ -1,7 +1,7 @@
-const { updateMatchingStatusApi, updateBothMatchingStatusApi } = require("../../../apis/matchApi");
+const { updateMatchingStatusApi } = require("../../../apis/matchApi");
 const { getSocketIdByMatchingUuid } = require("../../../common/memberSocketMapper");
 const { handleSocketError } = require("./matchingManager");
-const { deleteMySocketFromMatching } = require("./matchingManager");
+const { deleteMySocketFromMatching, getUserCountsInMatchingRoom } = require("./matchingManager");
 const log = require("../../../../common/customLogger");
 
 const {
@@ -53,8 +53,10 @@ async function handleMatchingNotFound(socket, io) {
             return;
         }
     }
+    const roomName=socket.data.matching.roomName;
+    deleteMySocketFromMatching(socket, io,roomName);
+    getUserCountsInMatchingRoom(socket,io,roomName);
 
-    deleteMySocketFromMatching(socket, io, socket.data.matching.roomName);
     socket.data.matching = null;
 }
 
@@ -63,8 +65,7 @@ async function handleMatchingNotFound(socket, io) {
  * @param {*} socket 
  * @returns 
  */
-async function handleMatchingFail(socket) {
-
+async function handleMatchingFail(socket,io) {
     // 매칭 status 변경
     if (socket.data.matching.gameMode) {
         try {
@@ -75,6 +76,7 @@ async function handleMatchingFail(socket) {
             return;
         }
     }
+    getUserCountsInMatchingRoom(socket,io,socket.data.matching.roomName);
 
     // 매칭 관련 데이터 초기화
     socket.data.matching = null;
@@ -99,7 +101,10 @@ async function handleMatchingQuit(socket, io) {
         }
     }
 
-    deleteMySocketFromMatching(socket, io, socket.data.matching.roomName);
+    const roomName=socket.data.matching.roomName;
+    deleteMySocketFromMatching(socket, io,roomName);
+    getUserCountsInMatchingRoom(socket,io,roomName);
+
     socket.data.matching = null;
 }
 

--- a/socket/handlers/matching/matchingHandler/matchingFailHandler.js
+++ b/socket/handlers/matching/matchingHandler/matchingFailHandler.js
@@ -38,11 +38,11 @@ async function handleMatchingReject(socket, io) {
 }
 
 /**
- * # 3-13. "matching-not-found"
+ * "matching-not-found"
  * @param {*} socket 
  */
 async function handleMatchingNotFound(socket, io) {
-    log.info(`matching-not-found`, socket);
+    log.debug(`matching-not-found`, socket);
 
     if (socket.data.matching.gameMode) {
         try {
@@ -54,7 +54,7 @@ async function handleMatchingNotFound(socket, io) {
         }
     }
     const roomName=socket.data.matching.roomName;
-    deleteMySocketFromMatching(socket, io,roomName);
+    deleteMySocketFromMatching(socket, io,roomName);   
     getUserCountsInMatchingRoom(socket,io,roomName);
 
     socket.data.matching = null;
@@ -76,7 +76,6 @@ async function handleMatchingFail(socket,io) {
             return;
         }
     }
-    getUserCountsInMatchingRoom(socket,io,socket.data.matching.roomName);
 
     // 매칭 관련 데이터 초기화
     socket.data.matching = null;

--- a/socket/handlers/matching/matchingHandler/matchingManager.js
+++ b/socket/handlers/matching/matchingHandler/matchingManager.js
@@ -2,7 +2,7 @@ const JWTTokenError = require("../../../../common/JWTTokenError");
 const log = require("../../../../common/customLogger");
 const { getSocketIdByMatchingUuid } = require("../../../common/memberSocketMapper");
 const { emitError, emitJWTError } = require("../../../emitters/errorEmitter");
-
+const { emitMatchingRoomStatus } = require("../../../emitters/matchingEmitter");
 /**
  * 내 우선순위 트리 갱신
  * @param {*} socket
@@ -19,7 +19,7 @@ function updatePriorityTree(socket, priorityList) {
   // 내 소켓에 다른 사용자 우선순위 값 넣기
   for (const item of priorityList) {
     if (!socket.data.matching.priorityTree.contains(item.matchingUuid)) {
-      socket.data.matching.priorityTree.insert(item.matchingUuid, item.priorityValue);    
+      socket.data.matching.priorityTree.insert(item.matchingUuid, item.priorityValue);
     } else {
       log.warn(`# 8) ${item.matchingUuid} is already in priorityTree`, socket);
     }
@@ -70,8 +70,8 @@ async function updateOtherPriorityTrees(io, socket, otherPriorityList) {
       if (otherSocket.data.matching.priorityTree.root) {
         otherSocket.data.matching.highestPriorityNode = otherSocket.data.matching.priorityTree.getMax(otherSocket.data.matching.priorityTree.root);
       }
-      
-      if (otherSocket.data.matching.highestPriorityNode){
+
+      if (otherSocket.data.matching.highestPriorityNode) {
         log.info("# 9) No highest priority node found in other socket", otherSocket);
       }
     } else {
@@ -102,13 +102,13 @@ async function findMatching(socket, io, threshold) {
       const node = otherSocket.data.matching.priorityTree.getNode(matchingUuid);
 
       // otherSocket이 내 매칭 정보에 대한 노드를 가지고 있지 않은 경우
-      if (!node) { 
+      if (!node) {
         log.warn(`# 10) Other socket (memberId: ${otherSocket.memberId}) has no priority node for matchingUuid: ${matchingUuid}`, otherSocket);
         return null;
       }
 
       // 해당 otherSocket의 내 매칭 정보에 대한 priorityValue가 threshold를 넘을 경우
-      if (node.priorityValue >= threshold) { 
+      if (node.priorityValue >= threshold) {
         log.info(`# 10) Matching found with socket memberId: ${otherSocket.memberId} meeting threshold ${threshold}`, socket);
         return otherSocket;
       } else {
@@ -179,15 +179,15 @@ function deleteMySocketFromMatching(socket, io, roomName) {
   const room = io.sockets.adapter.rooms.get(roomName);
 
   if (room) {
-      room.forEach((socketId) => {
-          const roomSocket = io.sockets.sockets.get(socketId);
-          if (roomSocket) {
-              roomSocket.data.matching.priorityTree.removeBymatchingUuid(socket.data.matching.matchingUuid);
-              log.debug(`# 17) Removed matchingUuid: ${socket.data.matching.matchingUuid} from socket ${roomSocket.id}'s priority tree`, roomSocket);
-          }
-      });
+    room.forEach((socketId) => {
+      const roomSocket = io.sockets.sockets.get(socketId);
+      if (roomSocket) {
+        roomSocket.data.matching.priorityTree.removeBymatchingUuid(socket.data.matching.matchingUuid);
+        log.debug(`# 17) Removed matchingUuid: ${socket.data.matching.matchingUuid} from socket ${roomSocket.id}'s priority tree`, roomSocket);
+      }
+    });
   } else {
-      log.warn(`# 16) Room ${roomName} does not exist or is empty`, socket);
+    log.warn(`# 16) Room ${roomName} does not exist or is empty`, socket);
   }
 
   // 18) priorityTree 삭제
@@ -198,11 +198,59 @@ function deleteMySocketFromMatching(socket, io, roomName) {
   socket.data.matching.highestPriorityNode = null;
 }
 
+/**
+ * 매칭 룸 사용자 수 emit
+ * @param {*} socket 
+ * @param {*} io 
+ * @param {*} roomName 
+ * @returns 
+ */
+function getUserCountsInMatchingRoom(socket, io, roomName) {
+  log.debug(`# ) matching count start`, socket);
+
+  // 매칭 룸 정보 얻기
+  const room = io.sockets.adapter.rooms.get(roomName);
+  if (!room) {
+    log.warn(`# 16) Room ${roomName} does not exist or is empty`, socket);
+    return;
+  }
+
+  // 각 티어별로 몇 명 있는지
+  let userCountByTier = {
+    UNRANKED: 0, IRON: 0, BRONZE: 0, SILVER: 0, GOLD: 0,
+    PLATINUM: 0, EMERALD: 0, DIAMOND: 0, MASTER: 0,
+    GRANDMASTER: 0, CHALLENGER: 0,
+  };
+
+  // 매칭룸에 총 몇 명 있는지 
+  let userCount = 0;
+
+  // 사용자 수 갱신
+  room.forEach((socketId) => {
+    const roomSocket = io.sockets.sockets.get(socketId);
+    if (roomSocket) {
+      const tier = roomSocket.data?.matching?.myMatchingInfo?.tier;
+      if (tier && tier in userCountByTier) {
+        userCountByTier[tier]++;
+      } else {
+        log.warn(`Unknown or missing tier for socket ${socketId}`);
+      }
+      userCount++;
+    }
+  });
+  console.log(userCount);
+  console.log(userCountByTier);
+
+  // 모든 사용자에게 같은 정보 브로드캐스트
+  emitMatchingRoomStatus(io, roomName, userCount, userCountByTier);
+}
+
 module.exports = {
   updatePriorityTree,
   updateOtherPriorityTrees,
   handleSocketError,
   joinGameModeRoom,
   findMatching,
-  deleteMySocketFromMatching
+  deleteMySocketFromMatching,
+  getUserCountsInMatchingRoom
 };

--- a/socket/handlers/matching/matchingHandler/matchingManager.js
+++ b/socket/handlers/matching/matchingHandler/matchingManager.js
@@ -206,14 +206,10 @@ function deleteMySocketFromMatching(socket, io, roomName) {
  * @returns 
  */
 function getUserCountsInMatchingRoom(socket, io, roomName) {
-  log.debug(`# ) matching count start`, socket);
+  log.debug(`matching count start`, socket);
 
   // 매칭 룸 정보 얻기
   const room = io.sockets.adapter.rooms.get(roomName);
-  if (!room) {
-    log.warn(`# 16) Room ${roomName} does not exist or is empty`, socket);
-    return;
-  }
 
   // 각 티어별로 몇 명 있는지
   let userCountByTier = {
@@ -238,8 +234,6 @@ function getUserCountsInMatchingRoom(socket, io, roomName) {
       userCount++;
     }
   });
-  console.log(userCount);
-  console.log(userCountByTier);
 
   // 모든 사용자에게 같은 정보 브로드캐스트
   emitMatchingRoomStatus(io, roomName, userCount, userCountByTier);

--- a/socket/handlers/matching/matchingHandler/matchingRequestHandler.js
+++ b/socket/handlers/matching/matchingHandler/matchingRequestHandler.js
@@ -74,8 +74,6 @@ async function handleMatchingRequest(socket, io, request) {
             matchingFoundReceiverRequest.senderMatchingInfo = socket.data.matching.myMatchingInfo;
             matchingFoundReceiverRequest.receiverMatchingUuid = receiverSocket.data.matching.matchingUuid;
 
-            getUserCountsInMatchingRoom(socket, io, roomName);
-
             // 12) "matching-found-receiver" emit
             emitMatchingFoundReceiver(receiverSocket, matchingFoundReceiverRequest);
         } else {

--- a/socket/handlers/matching/matchingHandler/matchingRequestHandler.js
+++ b/socket/handlers/matching/matchingHandler/matchingRequestHandler.js
@@ -1,5 +1,5 @@
 const { fetchMatchingApi } = require("../../../apis/matchApi");
-const { updateOtherPriorityTrees, updatePriorityTree, handleSocketError, joinGameModeRoom, findMatching } = require("./matchingManager");
+const { updateOtherPriorityTrees, updatePriorityTree, handleSocketError, joinGameModeRoom, findMatching, getUserCountsInMatchingRoom } = require("./matchingManager");
 const { isSocketActiveAndInRoom } = require("./matchingCommonHandler");
 const { emitError } = require("../../../emitters/errorEmitter");
 const log = require("../../../../common/customLogger");
@@ -47,6 +47,9 @@ async function handleMatchingRequest(socket, io, request) {
 
             // 7) "matching-started" emit
             emitMatchingStarted(socket, result.myMatchingInfo);
+
+            // TODO: matching-count emit
+            getUserCountsInMatchingRoom(socket,io,roomName);
 
             log.info(`# 8) myPriorityList : ${JSON.stringify(result.myPriorityList)}`, socket);
 

--- a/socket/handlers/matching/matchingHandler/matchingSuccessHandler.js
+++ b/socket/handlers/matching/matchingHandler/matchingSuccessHandler.js
@@ -1,6 +1,6 @@
 const { matchingFoundApi, matchingSuccessApi } = require("../../../apis/matchApi");
 const { getSocketIdByMatchingUuid } = require("../../../common/memberSocketMapper");
-const { handleSocketError, deleteMySocketFromMatching } = require("./matchingManager");
+const { handleSocketError, deleteMySocketFromMatching, getUserCountsInMatchingRoom } = require("./matchingManager");
 const log = require("../../../../common/customLogger");
 
 const {
@@ -11,13 +11,14 @@ const {
 } = require("../../../emitters/matchingEmitter");
 
 /**
- * # 1-13. "matching-found-receiver"
+ * # 1-13. "matching-found-success"
  * @param {*} socket 
  * @param {*} io 
  * @param {*} request 
  * @returns 
  */
 async function handleMatchingFoundSuccess(socket, io, request) {
+
     const matchingUuid = socket.data.matching.matchingUuid;
     const senderMatchingUuid = request.senderMatchingUuid;
     const senderSocket = await getSocketIdByMatchingUuid(io, senderMatchingUuid);
@@ -41,7 +42,8 @@ async function handleMatchingFoundSuccess(socket, io, request) {
     deleteMySocketFromMatching(socket, io, roomName);
     deleteMySocketFromMatching(senderSocket, io, roomName);
     log.info(`# 16~18) Deleted sockets from matching room: ${roomName}`, socket);
-
+    
+    getUserCountsInMatchingRoom(socket,io,roomName);
     try {
         const result = await matchingFoundApi(socket, matchingUuid, senderMatchingUuid);
         if (result) {

--- a/socket/handlers/matching/matchingSocketListeners.js
+++ b/socket/handlers/matching/matchingSocketListeners.js
@@ -13,7 +13,7 @@ function setupMatchSocketListeners(socket, io) {
   socket.on("matching-success-final", () => handleMatchingSuccessFinal(socket, io));
   socket.on("matching-not-found", () => handleMatchingNotFound(socket, io));
   socket.on("matching-reject", () => handleMatchingReject(socket, io));
-  socket.on("matching-fail", () => handleMatchingFail(socket));
+  socket.on("matching-fail", () => handleMatchingFail(socket, io));
   socket.on("matching-quit", () => handleMatchingQuit(socket, io));
 }
 

--- a/socket/socket.js
+++ b/socket/socket.js
@@ -21,7 +21,7 @@ const { emitError, emitJWTError, emitConnectionJwtError, emitJwtExpiredError } =
 const { fetchFriends } = require("./apis/friendApi");
 
 const { getSocketIdsByMemberIds } = require("./common/memberSocketMapper");
-const { deleteMySocketFromMatching } = require("./handlers/matching/matchingHandler/matchingManager");
+const { deleteMySocketFromMatching, getUserCountsInMatchingRoom } = require("./handlers/matching/matchingHandler/matchingManager");
 
 function initializeSocket(server) {
   const io = socketIo(server, {
@@ -160,12 +160,13 @@ function initializeSocket(server) {
       // 해당 socket이 memberId를 가질 때에만(로그인한 소켓인 경우에만)
       if (socket.memberId) {
         // (#6-2) 매칭 status 변경 API 요청
-        if (socket.data.matching.gameMode != null) {
+        if (socket.data?.matching?.gameMode != null) {
           updateMatchingStatusApi(socket, "QUIT");
 
           // (#6-4) 매칭 room에 join 되어 있는 경우, 해당 room의 모든 소켓의 priorityTree 에서 해당 소켓 노드 제거
           const roomName = "GAMEMODE_" + socket.data.matching.gameMode;
-          log.debug(`Removing socket from all priorityTree`,socket);
+          getUserCountsInMatchingRoom(socket, io, roomName);
+          log.debug(`Removing socket from all priorityTree`, socket);
           deleteMySocketFromMatching(socket, io, roomName);
         }
 


### PR DESCRIPTION
# 🚀 개요

<!-- 이 PR을 한 줄로 간략하게 설명해주세요. -->

> 매칭 내 사용자 수 실시간으로 나타내기

## ⏳ 작업 상세 내용

- [x] 같은 게임 모드에서  매칭 내 전체 사용자 수, 티어별 사용자 수 emit하는 소켓 이벤트 구현
- [x] **matchig-started emit 직전, matching-found에서 두 소켓이 매칭 룸을 나간 직후, matching-not-found 데이터 초기화 직후, matching-quit 데이터 초기화 직후, disconnect 데이터 초기화 직후**에 소켓 이벤트 emit

## 📝 더 꼼꼼히 봐야할 부분

<!-- 이 PR에 대해 의견을 묻고 싶은 부분이나 논의 사항, 더 집중적으로 리뷰가 필요한 것들을 적어주세요. -->

- [x] figma flow 변경 (파란색으로 표시됨)

## 🔍 반드시 참고해야하는 변경 사항

<!-- 이 PR로 인해 바꿔서 개발을 진행해야하는 것들을 목록으로 적어주세요. -->
<!-- ex) 환경 변수, 변수명, DB 관련 설정 등등 -->

- [x] 없을 경우 체크
