### PR TITLE
[Fix/151] 매칭 오브젝트 초기화 수정

### DIFF
--- a/socket/handlers/matching/matchingHandler/matchingFailHandler.js
+++ b/socket/handlers/matching/matchingHandler/matchingFailHandler.js
@@ -3,10 +3,21 @@ const { getSocketIdByMatchingUuid } = require("../../../common/memberSocketMappe
 const { handleSocketError } = require("./matchingManager");
 const { deleteMySocketFromMatching, getUserCountsInMatchingRoom } = require("./matchingManager");
 const log = require("../../../../common/customLogger");
+const { PriorityTree } = require("../../../common/PriorityTree");
 
 const {
     emitMatchingFail,
 } = require("../../../emitters/matchingEmitter");
+
+function _resetMatchingObject(socket) {
+    socket.data.matching = {
+        gameMode: null,
+        roomName: null,
+        myMatchingInfo: null,
+        matchingUuid: null,
+        priorityTree: new PriorityTree()
+    };
+}
 
 /**
  * # 4-27, 5-25. "matching-reject"
@@ -34,7 +45,7 @@ async function handleMatchingReject(socket, io) {
     }
 
     // 31. matching 관련 데이터 전부 초기화
-    socket.data.matching = null;
+    _resetMatchingObject(socket);
 }
 
 /**
@@ -57,7 +68,7 @@ async function handleMatchingNotFound(socket, io) {
     deleteMySocketFromMatching(socket, io,roomName);   
     getUserCountsInMatchingRoom(socket,io,roomName);
 
-    socket.data.matching = null;
+    _resetMatchingObject(socket);
 }
 
 /**
@@ -78,7 +89,7 @@ async function handleMatchingFail(socket,io) {
     }
 
     // 매칭 관련 데이터 초기화
-    socket.data.matching = null;
+    _resetMatchingObject(socket);
 }
 
 /**
@@ -104,7 +115,7 @@ async function handleMatchingQuit(socket, io) {
     deleteMySocketFromMatching(socket, io,roomName);
     getUserCountsInMatchingRoom(socket,io,roomName);
 
-    socket.data.matching = null;
+    _resetMatchingObject(socket);
 }
 
 module.exports = { handleMatchingReject, handleMatchingNotFound, handleMatchingFail, handleMatchingQuit };

--- a/socket/handlers/matching/matchingHandler/matchingFailHandler.js
+++ b/socket/handlers/matching/matchingHandler/matchingFailHandler.js
@@ -1,23 +1,13 @@
 const { updateMatchingStatusApi } = require("../../../apis/matchApi");
 const { getSocketIdByMatchingUuid } = require("../../../common/memberSocketMapper");
 const { handleSocketError } = require("./matchingManager");
-const { deleteMySocketFromMatching, getUserCountsInMatchingRoom } = require("./matchingManager");
+const { deleteMySocketFromMatching, getUserCountsInMatchingRoom, resetMatchingObject } = require("./matchingManager");
 const log = require("../../../../common/customLogger");
-const { PriorityTree } = require("../../../common/PriorityTree");
 
 const {
     emitMatchingFail,
 } = require("../../../emitters/matchingEmitter");
 
-function _resetMatchingObject(socket) {
-    socket.data.matching = {
-        gameMode: null,
-        roomName: null,
-        myMatchingInfo: null,
-        matchingUuid: null,
-        priorityTree: new PriorityTree()
-    };
-}
 
 /**
  * # 4-27, 5-25. "matching-reject"
@@ -25,7 +15,6 @@ function _resetMatchingObject(socket) {
  * @param {*} io 
  */
 async function handleMatchingReject(socket, io) {
-
     // matching target socket
     const otherSocket = await getSocketIdByMatchingUuid(io, socket.data.matching.matchingTargetUuid);
 
@@ -45,7 +34,7 @@ async function handleMatchingReject(socket, io) {
     }
 
     // 31. matching 관련 데이터 전부 초기화
-    _resetMatchingObject(socket);
+    resetMatchingObject(socket);
 }
 
 /**
@@ -67,8 +56,6 @@ async function handleMatchingNotFound(socket, io) {
     const roomName=socket.data.matching.roomName;
     deleteMySocketFromMatching(socket, io,roomName);   
     getUserCountsInMatchingRoom(socket,io,roomName);
-
-    _resetMatchingObject(socket);
 }
 
 /**
@@ -76,7 +63,7 @@ async function handleMatchingNotFound(socket, io) {
  * @param {*} socket 
  * @returns 
  */
-async function handleMatchingFail(socket,io) {
+async function handleMatchingFail(socket) {
     // 매칭 status 변경
     if (socket.data.matching.gameMode) {
         try {
@@ -89,7 +76,7 @@ async function handleMatchingFail(socket,io) {
     }
 
     // 매칭 관련 데이터 초기화
-    _resetMatchingObject(socket);
+    resetMatchingObject(socket);
 }
 
 /**
@@ -115,7 +102,6 @@ async function handleMatchingQuit(socket, io) {
     deleteMySocketFromMatching(socket, io,roomName);
     getUserCountsInMatchingRoom(socket,io,roomName);
 
-    _resetMatchingObject(socket);
 }
 
 module.exports = { handleMatchingReject, handleMatchingNotFound, handleMatchingFail, handleMatchingQuit };

--- a/socket/handlers/matching/matchingHandler/matchingManager.js
+++ b/socket/handlers/matching/matchingHandler/matchingManager.js
@@ -194,8 +194,7 @@ function deleteMySocketFromMatching(socket, io, roomName) {
   socket.data.matching.priorityTree.clear();
   log.info(`# 18) Cleared priority tree for socket ${socket.id}`, socket);
 
-  // 18) highestPriorityNode 삭제
-  socket.data.matching.highestPriorityNode = null;
+  resetMatchingObject(socket);
 }
 
 /**
@@ -252,6 +251,18 @@ function getUserCountsInMatchingRoom(socket, io, roomName) {
   emitMatchingRoomStatus(io, roomName, userCount, userCountByTier);
 }
 
+function resetMatchingObject(socket) {
+    socket.data.matching = {
+        gameMode: null,
+        roomName: null,
+        myMatchingInfo: null,
+        matchingUuid: null,
+        priorityTree: new PriorityTree(),
+        highestPriorityNode: null
+    };
+}
+
+
 module.exports = {
   updatePriorityTree,
   updateOtherPriorityTrees,
@@ -259,5 +270,6 @@ module.exports = {
   joinGameModeRoom,
   findMatching,
   deleteMySocketFromMatching,
-  getUserCountsInMatchingRoom
+  getUserCountsInMatchingRoom,
+  resetMatchingObject
 };


### PR DESCRIPTION
# 🚀 개요

<!-- 이 PR을 한 줄로 간략하게 설명해주세요. -->

> 매칭 실패 및 종료 처리 시 socket.data.matching 초기화 로직을 리팩토링하여 중복 코드를 제거하고, resetMatchingObject로 분리

## ⏳ 작업 상세 내용

- [x] matchingFailHandler.js 내 중복된 초기화 로직을 resetMatchingObject 함수로 수정


## 📝 더 꼼꼼히 봐야할 부분

<!-- 이 PR에 대해 의견을 묻고 싶은 부분이나 논의 사항, 더 집중적으로 리뷰가 필요한 것들을 적어주세요. -->

- [x] 없을 경우 체크

## 🔍 반드시 참고해야하는 변경 사항

<!-- 이 PR로 인해 바꿔서 개발을 진행해야하는 것들을 목록으로 적어주세요. -->
<!-- ex) 환경 변수, 변수명, DB 관련 설정 등등 -->

- [x] 없을 경우 체크
